### PR TITLE
feat: :sparkles: add JSON response helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ declare(strict_types=1);
 namespace App\Http\Actions;
 
 use AndrewDyer\Actions\AbstractAction;
-use AndrewDyer\Actions\Payloads\ActionError;
-use AndrewDyer\Actions\Payloads\ActionPayload;
 use Psr\Http\Message\ResponseInterface;
 
 final class PingAction extends AbstractAction
@@ -53,19 +51,10 @@ final class PingAction extends AbstractAction
         $mode = (string) $this->resolveArg('mode');
 
         if ($mode !== 'ok') {
-            return $this->respondWithJson(
-                ActionPayload::error(
-                    ActionError::badRequest('Mode must be "ok".'),
-                    400
-                )
-            );
+            return $this->badRequest('Mode must be "ok".');
         }
 
-        return $this->respondWithJson(
-            ActionPayload::success([
-                'message' => 'pong',
-            ])
-        );
+        return $this->ok(['message' => 'pong']);
     }
 }
 ```
@@ -128,6 +117,23 @@ Accept: application/json
   }
 }
 ```
+
+## Response helpers
+
+`AbstractAction` exposes the following protected helpers. Each one builds the correct `ActionPayload` and writes it to the response.
+
+| Method                                        | Status          | Error type                |
+| --------------------------------------------- | --------------- | ------------------------- |
+| `ok(mixed $data, int $statusCode = 200)`      | 200 (or custom) | —                         |
+| `badRequest(?string $description = null)`     | 400             | `BAD_REQUEST`             |
+| `unauthorized(?string $description = null)`   | 401             | `UNAUTHENTICATED`         |
+| `forbidden(?string $description = null)`      | 403             | `INSUFFICIENT_PRIVILEGES` |
+| `notFound(?string $description = null)`       | 404             | `RESOURCE_NOT_FOUND`      |
+| `notAllowed(?string $description = null)`     | 405             | `NOT_ALLOWED`             |
+| `serverError(?string $description = null)`    | 500             | `SERVER_ERROR`            |
+| `notImplemented(?string $description = null)` | 501             | `NOT_IMPLEMENTED`         |
+
+When you need full control over the payload you can still call `json(ActionPayloadInterface $payload)` directly.
 
 ## License
 

--- a/src/AbstractAction.php
+++ b/src/AbstractAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AndrewDyer\Actions;
 
 use AndrewDyer\Actions\Concerns\RespondsWithJson;
+use AndrewDyer\Actions\Contracts\ActionPayloadInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;

--- a/src/AbstractAction.php
+++ b/src/AbstractAction.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace AndrewDyer\Actions;
 
-use AndrewDyer\Actions\Contracts\ActionPayloadInterface;
-use JsonException;
+use AndrewDyer\Actions\Concerns\RespondsWithJson;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
@@ -17,6 +16,8 @@ use RuntimeException;
  */
 abstract class AbstractAction
 {
+    use RespondsWithJson;
+
     /**
      * Route arguments resolved from the matched URL pattern.
      */
@@ -103,6 +104,8 @@ abstract class AbstractAction
     /**
      * Serializes a payload to JSON and writes it to the response body.
      *
+     * @deprecated Use json() instead.
+     *
      * @param ActionPayloadInterface $payload The payload to serialize and send.
      *
      * @throws JsonException When the payload cannot be JSON-encoded.
@@ -111,14 +114,6 @@ abstract class AbstractAction
      */
     protected function respondWithJson(ActionPayloadInterface $payload): ResponseInterface
     {
-        $json = json_encode($payload, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
-
-        if ($json !== false) {
-            $this->response->getBody()->write($json);
-        }
-
-        return $this->response
-            ->withHeader('Content-Type', 'application/json; charset=utf-8')
-            ->withStatus($payload->getStatusCode());
+        return $this->json($payload);
     }
 }

--- a/src/Concerns/RespondsWithJson.php
+++ b/src/Concerns/RespondsWithJson.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AndrewDyer\Actions\Concerns;
+
+use AndrewDyer\Actions\Contracts\ActionPayloadInterface;
+use AndrewDyer\Actions\Payloads\ActionError;
+use AndrewDyer\Actions\Payloads\ActionPayload;
+use JsonException;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Provides JSON response helpers for action classes.
+ *
+ * This trait requires the consuming class to expose a PSR-7 ResponseInterface
+ * instance via the $response property, as AbstractAction does.
+ *
+ * @api
+ */
+trait RespondsWithJson
+{
+    /**
+     * Serializes a payload to JSON and writes it to the response body.
+     *
+     * @param ActionPayloadInterface $payload The payload to serialize and send.
+     *
+     * @throws JsonException When the payload cannot be JSON-encoded.
+     *
+     * @return ResponseInterface The response with the JSON body, Content-Type header, and status applied.
+     */
+    protected function json(ActionPayloadInterface $payload): ResponseInterface
+    {
+        $json = json_encode($payload, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        if ($json !== false) {
+            $this->response->getBody()->write($json);
+        }
+
+        return $this->response
+            ->withHeader('Content-Type', 'application/json; charset=utf-8')
+            ->withStatus($payload->getStatusCode());
+    }
+
+    /**
+     * Responds with a 200 OK JSON payload containing the given data.
+     *
+     * @param mixed $data       The response data to include in the payload.
+     * @param int   $statusCode The HTTP status code, defaults to 200.
+     *
+     * @throws JsonException When the payload cannot be JSON-encoded.
+     *
+     * @return ResponseInterface The JSON response.
+     */
+    protected function ok(mixed $data, int $statusCode = 200): ResponseInterface
+    {
+        return $this->json(ActionPayload::success($data, $statusCode));
+    }
+
+    /**
+     * Responds with a 400 Bad Request JSON error payload.
+     *
+     * @param string|null $description An optional human-readable description of the error.
+     *
+     * @throws JsonException When the payload cannot be JSON-encoded.
+     *
+     * @return ResponseInterface The JSON response.
+     */
+    protected function badRequest(?string $description = null): ResponseInterface
+    {
+        return $this->json(ActionPayload::error(ActionError::badRequest($description), 400));
+    }
+
+    /**
+     * Responds with a 401 Unauthorized JSON error payload.
+     *
+     * @param string|null $description An optional human-readable description of the error.
+     *
+     * @throws JsonException When the payload cannot be JSON-encoded.
+     *
+     * @return ResponseInterface The JSON response.
+     */
+    protected function unauthorized(?string $description = null): ResponseInterface
+    {
+        return $this->json(ActionPayload::error(ActionError::unauthenticated($description), 401));
+    }
+
+    /**
+     * Responds with a 403 Forbidden JSON error payload.
+     *
+     * @param string|null $description An optional human-readable description of the error.
+     *
+     * @throws JsonException When the payload cannot be JSON-encoded.
+     *
+     * @return ResponseInterface The JSON response.
+     */
+    protected function forbidden(?string $description = null): ResponseInterface
+    {
+        return $this->json(ActionPayload::error(ActionError::insufficientPrivileges($description), 403));
+    }
+
+    /**
+     * Responds with a 405 Method Not Allowed JSON error payload.
+     *
+     * @param string|null $description An optional human-readable description of the error.
+     *
+     * @throws JsonException When the payload cannot be JSON-encoded.
+     *
+     * @return ResponseInterface The JSON response.
+     */
+    protected function notAllowed(?string $description = null): ResponseInterface
+    {
+        return $this->json(ActionPayload::error(ActionError::notAllowed($description), 405));
+    }
+
+    /**
+     * Responds with a 404 Not Found JSON error payload.
+     *
+     * @param string|null $description An optional human-readable description of the error.
+     *
+     * @throws JsonException When the payload cannot be JSON-encoded.
+     *
+     * @return ResponseInterface The JSON response.
+     */
+    protected function notFound(?string $description = null): ResponseInterface
+    {
+        return $this->json(ActionPayload::error(ActionError::notFound($description), 404));
+    }
+
+    /**
+     * Responds with a 501 Not Implemented JSON error payload.
+     *
+     * @param string|null $description An optional human-readable description of the error.
+     *
+     * @throws JsonException When the payload cannot be JSON-encoded.
+     *
+     * @return ResponseInterface The JSON response.
+     */
+    protected function notImplemented(?string $description = null): ResponseInterface
+    {
+        return $this->json(ActionPayload::error(ActionError::notImplemented($description), 501));
+    }
+
+    /**
+     * Responds with a 500 Internal Server Error JSON error payload.
+     *
+     * @param string|null $description An optional human-readable description of the error.
+     *
+     * @throws JsonException When the payload cannot be JSON-encoded.
+     *
+     * @return ResponseInterface The JSON response.
+     */
+    protected function serverError(?string $description = null): ResponseInterface
+    {
+        return $this->json(ActionPayload::error(ActionError::serverError($description), 500));
+    }
+}

--- a/src/Concerns/RespondsWithJson.php
+++ b/src/Concerns/RespondsWithJson.php
@@ -33,9 +33,7 @@ trait RespondsWithJson
     {
         $json = json_encode($payload, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
-        if ($json !== false) {
-            $this->response->getBody()->write($json);
-        }
+        $this->response->getBody()->write($json);
 
         return $this->response
             ->withHeader('Content-Type', 'application/json; charset=utf-8')

--- a/tests/AbstractActionTest.php
+++ b/tests/AbstractActionTest.php
@@ -96,9 +96,9 @@ final class AbstractActionTest extends TestCase
     }
 
     /**
-     * Asserts that respondWithJson propagates a JsonException when encoding fails.
+     * Asserts that json propagates a JsonException when encoding fails.
      */
-    public function testRespondWithJsonThrowsWhenEncodingFails(): void
+    public function testJsonThrowsWhenEncodingFails(): void
     {
         $serverRequestFactory = new ServerRequestFactory();
         $request = $serverRequestFactory->createServerRequest('GET', '/invalid');
@@ -108,7 +108,7 @@ final class AbstractActionTest extends TestCase
 
         $action = new class () extends AbstractAction {
             /**
-             * Processes the request by writing an invalid UTF-8 payload to trigger a JSON encoding failure.
+             * Returns a response using json with an invalid UTF-8 payload to trigger a JSON encoding failure.
              *
              * @throws JsonException When the payload cannot be JSON-encoded.
              *

--- a/tests/AbstractActionTest.php
+++ b/tests/AbstractActionTest.php
@@ -19,9 +19,9 @@ use Slim\Psr7\Factory\ServerRequestFactory;
 final class AbstractActionTest extends TestCase
 {
     /**
-     * Asserts that respondWithJson writes the expected headers and payload.
+     * Asserts that json writes the expected headers and payload.
      */
-    public function testRespondWithJsonWritesPayloadAndHeaders(): void
+    public function testJsonWritesPayloadAndHeaders(): void
     {
         $serverRequestFactory = new ServerRequestFactory();
         $request = $serverRequestFactory

--- a/tests/AbstractActionTest.php
+++ b/tests/AbstractActionTest.php
@@ -14,16 +14,12 @@ use Slim\Psr7\Factory\ResponseFactory;
 use Slim\Psr7\Factory\ServerRequestFactory;
 
 /**
- * Validates the AbstractAction helper behavior.
- *
- * @internal
+ * Unit tests for AbstractAction.
  */
 final class AbstractActionTest extends TestCase
 {
     /**
-     * Ensures respondWithJson writes headers and serialized payloads.
-     *
-     * @return void
+     * Asserts that respondWithJson writes the expected headers and payload.
      */
     public function testRespondWithJsonWritesPayloadAndHeaders(): void
     {
@@ -60,9 +56,7 @@ final class AbstractActionTest extends TestCase
     }
 
     /**
-     * Ensures getParsedBody rejects unsupported payload types.
-     *
-     * @return void
+     * Asserts that getParsedBody throws when the body is not an array.
      */
     public function testGetParsedBodyThrowsWhenBodyIsNotArray(): void
     {
@@ -83,9 +77,7 @@ final class AbstractActionTest extends TestCase
     }
 
     /**
-     * Asserts resolveArg throws when required arguments are absent.
-     *
-     * @return void
+     * Asserts that resolveArg throws when the argument is absent.
      */
     public function testResolveArgThrowsWhenMissing(): void
     {
@@ -104,9 +96,7 @@ final class AbstractActionTest extends TestCase
     }
 
     /**
-     * Ensures respondWithJson bubbles JsonException when encoding fails.
-     *
-     * @return void
+     * Asserts that respondWithJson propagates a JsonException when encoding fails.
      */
     public function testRespondWithJsonThrowsWhenEncodingFails(): void
     {
@@ -118,7 +108,9 @@ final class AbstractActionTest extends TestCase
 
         $action = new class () extends AbstractAction {
             /**
-             * Returns a payload containing an invalid UTF-8 sequence to trigger a JSON encoding failure.
+             * Processes the request by writing an invalid UTF-8 payload to trigger a JSON encoding failure.
+             *
+             * @throws JsonException When the payload cannot be JSON-encoded.
              *
              * @return ResponseInterface The response attempted by the action.
              */
@@ -126,7 +118,7 @@ final class AbstractActionTest extends TestCase
             {
                 $invalidUtf8 = "\xB1";
 
-                return $this->respondWithJson(
+                return $this->json(
                     ActionPayload::success(['payload' => $invalidUtf8])
                 );
             }

--- a/tests/Concerns/RespondsWithJsonTest.php
+++ b/tests/Concerns/RespondsWithJsonTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AndrewDyer\Actions\Tests\Concerns;
+
+use AndrewDyer\Actions\AbstractAction;
+use AndrewDyer\Actions\Payloads\ActionError;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Slim\Psr7\Factory\ResponseFactory;
+use Slim\Psr7\Factory\ServerRequestFactory;
+
+/**
+ * Unit tests for RespondsWithJson.
+ */
+final class RespondsWithJsonTest extends TestCase
+{
+    /**
+     * Factory for creating server requests used in tests.
+     */
+    private ServerRequestFactory $requestFactory;
+
+    /**
+     * Factory for creating HTTP responses used in tests.
+     */
+    private ResponseFactory $responseFactory;
+
+    /**
+     * Creates the request and response factories before each test.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->requestFactory = new ServerRequestFactory();
+        $this->responseFactory = new ResponseFactory();
+    }
+
+    /**
+     * Returns the response produced by invoking the action with a blank GET request.
+     *
+     * @param AbstractAction $action The action to dispatch.
+     *
+     * @return ResponseInterface The response returned by the action.
+     */
+    private function dispatch(AbstractAction $action): ResponseInterface
+    {
+        $request = $this->requestFactory->createServerRequest('GET', '/test');
+        $response = $this->responseFactory->createResponse();
+
+        return $action($request, $response, []);
+    }
+
+    /**
+     * Returns the response body decoded as an array.
+     *
+     * @param ResponseInterface $response The response to decode.
+     *
+     * @return array The decoded JSON body.
+     */
+    private function decodeBody(ResponseInterface $response): array
+    {
+        return json_decode((string)$response->getBody(), true);
+    }
+
+    /**
+     * Asserts that ok method returns 200 with a data payload.
+     */
+    public function testOkReturns200(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->ok(['message' => 'pong']);
+            }
+        };
+
+        $response = $this->dispatch($action);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(['data' => ['message' => 'pong']], $this->decodeBody($response));
+    }
+
+    /**
+     * Asserts that ok method honours a custom status code.
+     */
+    public function testOkHonoursCustomStatusCode(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->ok(['id' => 1], 201);
+            }
+        };
+
+        $response = $this->dispatch($action);
+
+        self::assertSame(201, $response->getStatusCode());
+    }
+
+    /**
+     * Asserts that badRequest method returns 400 with a BAD_REQUEST error type.
+     */
+    public function testBadRequestReturns400(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->badRequest('Invalid input.');
+            }
+        };
+
+        $response = $this->dispatch($action);
+
+        self::assertSame(400, $response->getStatusCode());
+
+        $body = $this->decodeBody($response);
+        self::assertSame(ActionError::BAD_REQUEST, $body['error']['type']);
+        self::assertSame('Invalid input.', $body['error']['description']);
+    }
+
+    /**
+     * Asserts that badRequest method accepts a null description.
+     */
+    public function testBadRequestAcceptsNullDescription(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->badRequest();
+            }
+        };
+
+        $response = $this->dispatch($action);
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertNull($this->decodeBody($response)['error']['description']);
+    }
+
+    /**
+     * Asserts that unauthorized method returns 401 with an UNAUTHENTICATED error type.
+     */
+    public function testUnauthorizedReturns401(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->unauthorized('Token expired.');
+            }
+        };
+
+        $response = $this->dispatch($action);
+
+        self::assertSame(401, $response->getStatusCode());
+        self::assertSame(ActionError::UNAUTHENTICATED, $this->decodeBody($response)['error']['type']);
+    }
+
+    /**
+     * Asserts that forbidden method returns 403 with an INSUFFICIENT_PRIVILEGES error type.
+     */
+    public function testForbiddenReturns403(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->forbidden('Access denied.');
+            }
+        };
+
+        $response = $this->dispatch($action);
+
+        self::assertSame(403, $response->getStatusCode());
+        self::assertSame(ActionError::INSUFFICIENT_PRIVILEGES, $this->decodeBody($response)['error']['type']);
+    }
+
+    /**
+     * Asserts that notFound method returns 404 with a RESOURCE_NOT_FOUND error type.
+     */
+    public function testNotFoundReturns404(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->notFound('Item not found.');
+            }
+        };
+
+        $response = $this->dispatch($action);
+
+        self::assertSame(404, $response->getStatusCode());
+        self::assertSame(ActionError::RESOURCE_NOT_FOUND, $this->decodeBody($response)['error']['type']);
+    }
+
+    /**
+     * Asserts that notAllowed method returns 405 with a NOT_ALLOWED error type.
+     */
+    public function testNotAllowedReturns405(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->notAllowed('Method not allowed.');
+            }
+        };
+
+        $response = $this->dispatch($action);
+
+        self::assertSame(405, $response->getStatusCode());
+        self::assertSame(ActionError::NOT_ALLOWED, $this->decodeBody($response)['error']['type']);
+    }
+
+    /**
+     * Asserts that notImplemented method returns 501 with a NOT_IMPLEMENTED error type.
+     */
+    public function testNotImplementedReturns501(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->notImplemented('Coming soon.');
+            }
+        };
+
+        $response = $this->dispatch($action);
+
+        self::assertSame(501, $response->getStatusCode());
+        self::assertSame(ActionError::NOT_IMPLEMENTED, $this->decodeBody($response)['error']['type']);
+    }
+
+    /**
+     * Asserts that serverError method returns 500 with a SERVER_ERROR error type.
+     */
+    public function testServerErrorReturns500(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->serverError('Unexpected failure.');
+            }
+        };
+
+        $response = $this->dispatch($action);
+
+        self::assertSame(500, $response->getStatusCode());
+        self::assertSame(ActionError::SERVER_ERROR, $this->decodeBody($response)['error']['type']);
+    }
+}

--- a/tests/Concerns/RespondsWithJsonTest.php
+++ b/tests/Concerns/RespondsWithJsonTest.php
@@ -61,7 +61,13 @@ final class RespondsWithJsonTest extends TestCase
      */
     private function decodeBody(ResponseInterface $response): array
     {
-        return json_decode((string)$response->getBody(), true);
+        $decoded = json_decode((string)$response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        if (!is_array($decoded)) {
+            self::fail('Expected response body JSON to decode to an array.');
+        }
+
+        return $decoded;
     }
 
     /**

--- a/tests/TestAction.php
+++ b/tests/TestAction.php
@@ -18,11 +18,11 @@ final class TestAction extends AbstractAction
     /**
      * Builds a canned JSON payload using the request context.
      *
-     * @return ResponseInterface
+     * @return ResponseInterface The JSON response.
      */
     protected function handle(): ResponseInterface
     {
-        return $this->respondWithJson(
+        return $this->json(
             ActionPayload::success([
                 'message' => 'ok',
                 'body' => $this->getParsedBody(),


### PR DESCRIPTION
This pull request introduces a new trait, `RespondsWithJson`, to provide convenient JSON response helpers for action classes. The `AbstractAction` class now uses this trait, simplifying how actions return common HTTP responses. The documentation and tests have been updated to reflect and validate these changes.

**Key changes:**

### Response Helper Improvements

* Introduced the `RespondsWithJson` trait in `src/Concerns/RespondsWithJson.php`, providing protected helper methods like `ok`, `badRequest`, `unauthorized`, `forbidden`, `notFound`, `notAllowed`, `serverError`, and `notImplemented` for consistent JSON responses. (`[src/Concerns/RespondsWithJson.phpR1-R157](diffhunk://#diff-9acdee8e94a079f00e8b11743b09a97fe7ec7dd043a902e8c45aba56ceacfe27R1-R157)`)
* Updated `AbstractAction` to use the new `RespondsWithJson` trait, removing direct dependencies on payload classes and simplifying response logic. (`[[1]](diffhunk://#diff-116fe25fa78509c6571a37859b540883047cba7eb993aa7e7b36283849a8ace7L7-R7)`, `[[2]](diffhunk://#diff-116fe25fa78509c6571a37859b540883047cba7eb993aa7e7b36283849a8ace7R19-R20)`)

### Code and Usage Simplification

* Refactored example usage in `README.md` and in test/demo actions to use the new helpers (e.g., replacing `respondWithJson(ActionPayload::success(...))` with `$this->ok(...)`). (`[[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L56-R57)`, `[[2]](diffhunk://#diff-1e8daff4d9cf4d7aca18b647b7909f0d620457c4e470b7f2b7785c2b01a9708bL21-R25)`)
* Marked the old `respondWithJson` method as deprecated in `AbstractAction`, making it a thin wrapper around the new `json` method. (`[[1]](diffhunk://#diff-116fe25fa78509c6571a37859b540883047cba7eb993aa7e7b36283849a8ace7R107-R108)`, `[[2]](diffhunk://#diff-116fe25fa78509c6571a37859b540883047cba7eb993aa7e7b36283849a8ace7L114-R117)`)

### Documentation

* Added a new section to the `README.md` documenting all available response helper methods and their behavior, making it easier for users to understand and adopt the new helpers. (`[README.mdR121-R137](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R121-R137)`)

### Testing

* Added comprehensive unit tests for the new response helpers in `tests/Concerns/RespondsWithJsonTest.php`. (`[tests/Concerns/RespondsWithJsonTest.phpR1-R248](diffhunk://#diff-ccbe1fc51f0c05cd8abe4e25bbf939e28373bb825b3ebdc998ae699903632f8fR1-R248)`)
* Updated and clarified docblocks and test descriptions in existing tests for better readability and alignment with the new helpers. (`[[1]](diffhunk://#diff-9aee27bf40a1de5c43d3e4a2f820b75e20d4a3fe339f9dcdf5bbdf96df1b6dafL17-R22)`, `[[2]](diffhunk://#diff-9aee27bf40a1de5c43d3e4a2f820b75e20d4a3fe339f9dcdf5bbdf96df1b6dafL63-R59)`, `[[3]](diffhunk://#diff-9aee27bf40a1de5c43d3e4a2f820b75e20d4a3fe339f9dcdf5bbdf96df1b6dafL86-R80)`, `[[4]](diffhunk://#diff-9aee27bf40a1de5c43d3e4a2f820b75e20d4a3fe339f9dcdf5bbdf96df1b6dafL107-R99)`, `[[5]](diffhunk://#diff-9aee27bf40a1de5c43d3e4a2f820b75e20d4a3fe339f9dcdf5bbdf96df1b6dafL121-R121)`)

### Dependency Cleanup

* Removed unused imports from `AbstractAction` now that response helpers are provided by the trait. (`[README.mdL45-L46](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L45-L46)`)

These changes make it much easier to return standard JSON responses from actions, reduce boilerplate, and improve consistency across the codebase.