### PR TITLE
feat: :sparkles: add exception handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The examples below demonstrate how this library can be used with [Slim Framework
 
 ### 1. Create an action
 
-The action below reads a route argument and returns either a success or error JSON payload.
+The action validates the request, retrieves data, and returns a JSON response.
 
 ```php
 declare(strict_types=1);
@@ -44,49 +44,57 @@ namespace App\Http\Actions;
 use AndrewDyer\Actions\AbstractAction;
 use Psr\Http\Message\ResponseInterface;
 
-final class PingAction extends AbstractAction
+final class GetUserAction extends AbstractAction
 {
     protected function handle(): ResponseInterface
     {
-        $mode = (string) $this->resolveArg('mode');
+        $id = (string) $this->resolveArg('id');
 
-        if ($mode !== 'ok') {
-            return $this->badRequest('Mode must be "ok".');
+        if (!ctype_digit($id)) {
+            return $this->badRequest('User ID must be numeric.');
         }
 
-        return $this->ok(['message' => 'pong']);
+        if ((int) $id !== 123) {
+            return $this->notFound("User {$id} not found.");
+        }
+
+        return $this->ok([
+            'id' => (int) $id,
+            'name' => 'John Smith',
+            'email' => 'john.smith@example.com',
+        ]);
     }
 }
 ```
 
 ### 2. Register the route
 
-The action is wired into the Slim bootstrap so requests to `/ping/{mode}` are dispatched to the action class.
+The action is wired into the Slim bootstrap so requests to `/users/{id}` are dispatched to the action class.
 
 ```php
 declare(strict_types=1);
 
-use App\Http\Actions\PingAction;
+use App\Http\Actions\GetUserAction;
 use Slim\Factory\AppFactory;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $app = AppFactory::create();
 
-// If using a container, ensure PingAction is resolvable there.
-$app->get('/ping/{mode}', PingAction::class);
+// If using a container, ensure GetUserAction is resolvable there.
+$app->get('/users/{id}', GetUserAction::class);
 
 $app->run();
 ```
 
 ## Usage
 
-Once the route is registered, Slim will invoke the action and return the payload as JSON.
+Once the route is registered, Slim invokes the action and returns the payload as JSON.
 
 ### Successful request
 
 ```
-GET /ping/ok
+GET /users/123
 Accept: application/json
 ```
 
@@ -95,15 +103,17 @@ Accept: application/json
 ```json
 {
   "data": {
-    "message": "pong"
+    "id": 123,
+    "name": "John Smith",
+    "email": "john.smith@example.com"
   }
 }
 ```
 
-### Invalid request
+### Validation error
 
 ```
-GET /ping/nope
+GET /users/abc
 Accept: application/json
 ```
 
@@ -113,27 +123,75 @@ Accept: application/json
 {
   "error": {
     "type": "BAD_REQUEST",
-    "description": "Mode must be \"ok\"."
+    "description": "User ID must be numeric."
+  }
+}
+```
+
+### Resource not found
+
+```
+GET /users/999
+Accept: application/json
+```
+
+**Response: 404 Not Found**
+
+```json
+{
+  "error": {
+    "type": "RESOURCE_NOT_FOUND",
+    "description": "User 999 not found."
   }
 }
 ```
 
 ## Response helpers
 
-`AbstractAction` exposes the following protected helpers. Each one builds the correct `ActionPayload` and writes it to the response.
+Helper methods provided by `AbstractAction` generate structured JSON responses. Each builds the appropriate `ActionPayload` and writes it to the response.
 
-| Method                                        | Status          | Error type                |
-| --------------------------------------------- | --------------- | ------------------------- |
-| `ok(mixed $data, int $statusCode = 200)`      | 200 (or custom) | —                         |
-| `badRequest(?string $description = null)`     | 400             | `BAD_REQUEST`             |
-| `unauthorized(?string $description = null)`   | 401             | `UNAUTHENTICATED`         |
-| `forbidden(?string $description = null)`      | 403             | `INSUFFICIENT_PRIVILEGES` |
-| `notFound(?string $description = null)`       | 404             | `RESOURCE_NOT_FOUND`      |
-| `notAllowed(?string $description = null)`     | 405             | `NOT_ALLOWED`             |
-| `serverError(?string $description = null)`    | 500             | `SERVER_ERROR`            |
-| `notImplemented(?string $description = null)` | 501             | `NOT_IMPLEMENTED`         |
+| Method                                        | When to use                                      | Status          | Error type                |
+| --------------------------------------------- | ------------------------------------------------ | --------------- | ------------------------- |
+| `ok(mixed $data, int $statusCode = 200)`      | Successful operation with data payload           | 200 (or custom) | —                         |
+| `badRequest(?string $description = null)`     | Request is malformed or violates business rules  | 400             | `BAD_REQUEST`             |
+| `unauthorized(?string $description = null)`   | Request lacks valid authentication credentials   | 401             | `UNAUTHENTICATED`         |
+| `forbidden(?string $description = null)`      | Authenticated caller lacks required permissions  | 403             | `INSUFFICIENT_PRIVILEGES` |
+| `notFound(?string $description = null)`       | Requested resource does not exist                | 404             | `RESOURCE_NOT_FOUND`      |
+| `notAllowed(?string $description = null)`     | HTTP method not allowed for the resource         | 405             | `NOT_ALLOWED`             |
+| `serverError(?string $description = null)`    | Unexpected server error occurred                 | 500             | `SERVER_ERROR`            |
+| `notImplemented(?string $description = null)` | Requested functionality has not been implemented | 501             | `NOT_IMPLEMENTED`         |
 
-When you need full control over the payload you can still call `json(ActionPayloadInterface $payload)` directly.
+For full control over the payload, call `json(ActionPayloadInterface $payload)` directly.
+
+## Exception handling
+
+Domain exceptions are caught automatically by `AbstractAction` and mapped to appropriate HTTP responses. Extend the base exception classes to create domain-specific exceptions.
+
+| Base exception             | When to use                                      | Status | Error type                |
+| -------------------------- | ------------------------------------------------ | ------ | ------------------------- |
+| `BadRequestException`      | Request is malformed or violates business rules  | 400    | `BAD_REQUEST`             |
+| `UnauthenticatedException` | Request lacks valid authentication credentials   | 401    | `UNAUTHENTICATED`         |
+| `ForbiddenException`       | Authenticated caller lacks required permissions  | 403    | `INSUFFICIENT_PRIVILEGES` |
+| `NotFoundException`        | Requested resource does not exist                | 404    | `RESOURCE_NOT_FOUND`      |
+| `NotImplementedException`  | Requested functionality has not been implemented | 501    | `NOT_IMPLEMENTED`         |
+
+Example:
+
+```php
+declare(strict_types=1);
+
+namespace App\Domain\Exceptions;
+
+use AndrewDyer\Actions\Exceptions\NotFoundException;
+
+final class UserNotFoundException extends NotFoundException
+{
+    public function __construct(int $id)
+    {
+        parent::__construct("User {$id} not found.");
+    }
+}
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Helper methods provided by `AbstractAction` generate structured JSON responses. 
 | `serverError(?string $description = null)`    | Unexpected server error occurred                 | 500             | `SERVER_ERROR`            |
 | `notImplemented(?string $description = null)` | Requested functionality has not been implemented | 501             | `NOT_IMPLEMENTED`         |
 
+> **Note:** When the `description` parameter is `null`, the `description` field is omitted entirely from the error response. API consumers should treat `description` as an optional field.
+
 For full control over the payload, call `json(ActionPayloadInterface $payload)` directly.
 
 ## Exception handling
@@ -174,6 +176,8 @@ Domain exceptions are caught automatically by `AbstractAction` and mapped to app
 | `ForbiddenException`       | Authenticated caller lacks required permissions  | 403    | `INSUFFICIENT_PRIVILEGES` |
 | `NotFoundException`        | Requested resource does not exist                | 404    | `RESOURCE_NOT_FOUND`      |
 | `NotImplementedException`  | Requested functionality has not been implemented | 501    | `NOT_IMPLEMENTED`         |
+
+> **Note:** When an exception has an empty message, the `description` field is omitted from the error response. API consumers should treat `description` as an optional field.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ For full control over the payload, call `json(ActionPayloadInterface $payload)` 
 
 ## Exception handling
 
-Domain exceptions are caught automatically by `AbstractAction` and mapped to appropriate HTTP responses. Extend the base exception classes to create domain-specific exceptions.
+Domain exceptions are caught automatically by `AbstractAction` and mapped to appropriate HTTP responses. This is useful when exceptions are thrown from services, repositories, or other domain logic that should not be coupled to HTTP concerns. Extend the base exception classes to create domain-specific exceptions.
 
 | Base exception             | When to use                                      | Status | Error type                |
 | -------------------------- | ------------------------------------------------ | ------ | ------------------------- |

--- a/src/AbstractAction.php
+++ b/src/AbstractAction.php
@@ -60,15 +60,15 @@ abstract class AbstractAction
         try {
             return $this->handle();
         } catch (BadRequestExceptionInterface $e) {
-            return $this->badRequest($e->getMessage() ?: null);
+            return $this->badRequest($this->getExceptionMessage($e));
         } catch (ForbiddenExceptionInterface $e) {
-            return $this->forbidden($e->getMessage() ?: null);
+            return $this->forbidden($this->getExceptionMessage($e));
         } catch (NotFoundExceptionInterface $e) {
-            return $this->notFound($e->getMessage() ?: null);
+            return $this->notFound($this->getExceptionMessage($e));
         } catch (NotImplementedExceptionInterface $e) {
-            return $this->notImplemented($e->getMessage() ?: null);
+            return $this->notImplemented($this->getExceptionMessage($e));
         } catch (UnauthenticatedExceptionInterface $e) {
-            return $this->unauthorized($e->getMessage() ?: null);
+            return $this->unauthorized($this->getExceptionMessage($e));
         }
     }
 
@@ -78,6 +78,18 @@ abstract class AbstractAction
      * @return ResponseInterface The response produced by the action.
      */
     abstract protected function handle(): ResponseInterface;
+
+    /**
+     * Extracts the exception message, returning null for empty strings.
+     *
+     * @param \Throwable $e The exception to extract the message from.
+     *
+     * @return string|null The exception message, or null if empty.
+     */
+    private function getExceptionMessage(\Throwable $e): ?string
+    {
+        return $e->getMessage() !== '' ? $e->getMessage() : null;
+    }
 
     /**
      * Returns the parsed request body as an array.

--- a/src/AbstractAction.php
+++ b/src/AbstractAction.php
@@ -6,6 +6,7 @@ namespace AndrewDyer\Actions;
 
 use AndrewDyer\Actions\Concerns\RespondsWithJson;
 use AndrewDyer\Actions\Contracts\ActionPayloadInterface;
+use AndrewDyer\Actions\Contracts\BadRequestExceptionInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
@@ -52,7 +53,11 @@ abstract class AbstractAction
         $this->response = $response;
         $this->args = $args;
 
-        return $this->handle();
+        try {
+            return $this->handle();
+        } catch (BadRequestExceptionInterface $e) {
+            return $this->badRequest($e->getMessage() ?: null);
+        }
     }
 
     /**

--- a/src/AbstractAction.php
+++ b/src/AbstractAction.php
@@ -7,6 +7,7 @@ namespace AndrewDyer\Actions;
 use AndrewDyer\Actions\Concerns\RespondsWithJson;
 use AndrewDyer\Actions\Contracts\ActionPayloadInterface;
 use AndrewDyer\Actions\Contracts\BadRequestExceptionInterface;
+use AndrewDyer\Actions\Contracts\ForbiddenExceptionInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
@@ -57,7 +58,9 @@ abstract class AbstractAction
             return $this->handle();
         } catch (BadRequestExceptionInterface $e) {
             return $this->badRequest($e->getMessage() ?: null);
-        }
+        } catch (ForbiddenExceptionInterface $e) {
+            return $this->forbidden($e->getMessage() ?: null);
+        } 
     }
 
     /**

--- a/src/AbstractAction.php
+++ b/src/AbstractAction.php
@@ -9,6 +9,7 @@ use AndrewDyer\Actions\Contracts\ActionPayloadInterface;
 use AndrewDyer\Actions\Contracts\BadRequestExceptionInterface;
 use AndrewDyer\Actions\Contracts\ForbiddenExceptionInterface;
 use AndrewDyer\Actions\Contracts\NotFoundExceptionInterface;
+use AndrewDyer\Actions\Contracts\NotImplementedExceptionInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
@@ -63,6 +64,8 @@ abstract class AbstractAction
             return $this->forbidden($e->getMessage() ?: null);
         } catch (NotFoundExceptionInterface $e) {
             return $this->notFound($e->getMessage() ?: null);
+        } catch (NotImplementedExceptionInterface $e) {
+            return $this->notImplemented($e->getMessage() ?: null);
         }
     }
 

--- a/src/AbstractAction.php
+++ b/src/AbstractAction.php
@@ -8,6 +8,7 @@ use AndrewDyer\Actions\Concerns\RespondsWithJson;
 use AndrewDyer\Actions\Contracts\ActionPayloadInterface;
 use AndrewDyer\Actions\Contracts\BadRequestExceptionInterface;
 use AndrewDyer\Actions\Contracts\ForbiddenExceptionInterface;
+use AndrewDyer\Actions\Contracts\NotFoundExceptionInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
@@ -60,7 +61,9 @@ abstract class AbstractAction
             return $this->badRequest($e->getMessage() ?: null);
         } catch (ForbiddenExceptionInterface $e) {
             return $this->forbidden($e->getMessage() ?: null);
-        } 
+        } catch (NotFoundExceptionInterface $e) {
+            return $this->notFound($e->getMessage() ?: null);
+        }
     }
 
     /**

--- a/src/AbstractAction.php
+++ b/src/AbstractAction.php
@@ -10,6 +10,7 @@ use AndrewDyer\Actions\Contracts\BadRequestExceptionInterface;
 use AndrewDyer\Actions\Contracts\ForbiddenExceptionInterface;
 use AndrewDyer\Actions\Contracts\NotFoundExceptionInterface;
 use AndrewDyer\Actions\Contracts\NotImplementedExceptionInterface;
+use AndrewDyer\Actions\Contracts\UnauthenticatedExceptionInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
@@ -66,6 +67,8 @@ abstract class AbstractAction
             return $this->notFound($e->getMessage() ?: null);
         } catch (NotImplementedExceptionInterface $e) {
             return $this->notImplemented($e->getMessage() ?: null);
+        } catch (UnauthenticatedExceptionInterface $e) {
+            return $this->unauthorized($e->getMessage() ?: null);
         }
     }
 

--- a/src/Contracts/BadRequestExceptionInterface.php
+++ b/src/Contracts/BadRequestExceptionInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AndrewDyer\Actions\Contracts;
+
+use Throwable;
+
+/**
+ * Marker interface for exceptions that represent a "bad request" condition.
+ *
+ * Actions implementing the ADR pattern may throw exceptions that implement this
+ * interface to signal that the request is malformed or violates business rules.
+ * AbstractAction catches any BadRequestExceptionInterface and returns a 400 JSON
+ * response, without requiring knowledge of the HTTP layer in the throwing class.
+ *
+ * @api
+ */
+interface BadRequestExceptionInterface extends Throwable
+{
+}

--- a/src/Contracts/ForbiddenExceptionInterface.php
+++ b/src/Contracts/ForbiddenExceptionInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AndrewDyer\Actions\Contracts;
+
+use Throwable;
+
+/**
+ * Marker interface for exceptions that represent a "forbidden" condition.
+ *
+ * Actions implementing the ADR pattern may throw exceptions that implement this
+ * interface to signal that the authenticated caller lacks the required permissions.
+ * AbstractAction catches any ForbiddenExceptionInterface and returns a 403 JSON
+ * response, without requiring knowledge of the HTTP layer in the throwing class.
+ *
+ * @api
+ */
+interface ForbiddenExceptionInterface extends Throwable
+{
+}

--- a/src/Contracts/NotFoundExceptionInterface.php
+++ b/src/Contracts/NotFoundExceptionInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AndrewDyer\Actions\Contracts;
+
+use Throwable;
+
+/**
+ * Marker interface for exceptions that represent a "resource not found" condition.
+ *
+ * Actions implementing the ADR pattern may throw exceptions that implement this
+ * interface to signal that the requested resource does not exist. AbstractAction
+ * catches any NotFoundExceptionInterface and returns a 404 JSON response, without
+ * requiring knowledge of the HTTP layer in the throwing class.
+ *
+ * @api
+ */
+interface NotFoundExceptionInterface extends Throwable
+{
+}

--- a/src/Contracts/NotImplementedExceptionInterface.php
+++ b/src/Contracts/NotImplementedExceptionInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AndrewDyer\Actions\Contracts;
+
+use Throwable;
+
+/**
+ * Marker interface for exceptions that represent a "not implemented" condition.
+ *
+ * Actions implementing the ADR pattern may throw exceptions that implement this
+ * interface to signal that the requested functionality has not yet been implemented.
+ * AbstractAction catches any NotImplementedExceptionInterface and returns a 501
+ * JSON response, without requiring knowledge of the HTTP layer in the throwing class.
+ *
+ * @api
+ */
+interface NotImplementedExceptionInterface extends Throwable
+{
+}

--- a/src/Contracts/UnauthenticatedExceptionInterface.php
+++ b/src/Contracts/UnauthenticatedExceptionInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AndrewDyer\Actions\Contracts;
+
+use Throwable;
+
+/**
+ * Marker interface for exceptions that represent an "unauthenticated" condition.
+ *
+ * Actions implementing the ADR pattern may throw exceptions that implement this
+ * interface to signal that the request lacks valid authentication credentials.
+ * AbstractAction catches any UnauthenticatedExceptionInterface and returns a 401
+ * JSON response, without requiring knowledge of the HTTP layer in the throwing class.
+ *
+ * @api
+ */
+interface UnauthenticatedExceptionInterface extends Throwable
+{
+}

--- a/src/Exceptions/BadRequestException.php
+++ b/src/Exceptions/BadRequestException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AndrewDyer\Actions\Exceptions;
+
+use AndrewDyer\Actions\Contracts\BadRequestExceptionInterface;
+use Exception;
+
+/**
+ * Concrete exception representing a "bad request" condition.
+ *
+ * Domain-specific exceptions should extend this class to signal that a request
+ * is malformed or violates business rules, allowing the action layer to automatically
+ * return a 400 JSON response without coupling to HTTP concerns.
+ *
+ * @api
+ */
+class BadRequestException extends Exception implements BadRequestExceptionInterface
+{
+}

--- a/src/Exceptions/ForbiddenException.php
+++ b/src/Exceptions/ForbiddenException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AndrewDyer\Actions\Exceptions;
+
+use AndrewDyer\Actions\Contracts\ForbiddenExceptionInterface;
+use Exception;
+
+/**
+ * Concrete exception representing a "forbidden" condition.
+ *
+ * Domain-specific exceptions should extend this class to signal that the authenticated
+ * caller lacks the required permissions, allowing the action layer to automatically
+ * return a 403 JSON response without coupling to HTTP concerns.
+ *
+ * @api
+ */
+class ForbiddenException extends Exception implements ForbiddenExceptionInterface
+{
+}

--- a/src/Exceptions/NotFoundException.php
+++ b/src/Exceptions/NotFoundException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AndrewDyer\Actions\Exceptions;
+
+use AndrewDyer\Actions\Contracts\NotFoundExceptionInterface;
+use Exception;
+
+/**
+ * Concrete exception representing a "resource not found" condition.
+ *
+ * Domain-specific exceptions should extend this class to signal that a requested
+ * resource does not exist, allowing the action layer to automatically return a
+ * 404 JSON response without coupling to HTTP concerns.
+ *
+ * @api
+ */
+class NotFoundException extends Exception implements NotFoundExceptionInterface
+{
+}

--- a/src/Exceptions/NotImplementedException.php
+++ b/src/Exceptions/NotImplementedException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AndrewDyer\Actions\Exceptions;
+
+use AndrewDyer\Actions\Contracts\NotImplementedExceptionInterface;
+use Exception;
+
+/**
+ * Concrete exception representing a "not implemented" condition.
+ *
+ * Domain-specific exceptions should extend this class to signal that the requested
+ * functionality has not yet been implemented, allowing the action layer to automatically
+ * return a 501 JSON response without coupling to HTTP concerns.
+ *
+ * @api
+ */
+class NotImplementedException extends Exception implements NotImplementedExceptionInterface
+{
+}

--- a/src/Exceptions/UnauthenticatedException.php
+++ b/src/Exceptions/UnauthenticatedException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AndrewDyer\Actions\Exceptions;
+
+use AndrewDyer\Actions\Contracts\UnauthenticatedExceptionInterface;
+use Exception;
+
+/**
+ * Concrete exception representing an "unauthenticated" condition.
+ *
+ * Domain-specific exceptions should extend this class to signal that a request
+ * lacks valid authentication credentials, allowing the action layer to automatically
+ * return a 401 JSON response without coupling to HTTP concerns.
+ *
+ * @api
+ */
+class UnauthenticatedException extends Exception implements UnauthenticatedExceptionInterface
+{
+}

--- a/src/Payloads/AbstractActionError.php
+++ b/src/Payloads/AbstractActionError.php
@@ -48,13 +48,16 @@ abstract readonly class AbstractActionError implements ActionErrorInterface
     /**
      * Maps the error payload to an array for JSON encoding.
      *
-     * @return array{type:string,description:?string} The serialized fields of the error.
+     * @return array{type:string,description?:string} The serialized fields of the error.
      */
     public function jsonSerialize(): array
     {
-        return [
-            'type' => $this->type,
-            'description' => $this->description,
-        ];
+        $payload = ['type' => $this->type];
+
+        if ($this->description !== null) {
+            $payload['description'] = $this->description;
+        }
+
+        return $payload;
     }
 }

--- a/tests/AbstractActionTest.php
+++ b/tests/AbstractActionTest.php
@@ -8,6 +8,7 @@ use AndrewDyer\Actions\AbstractAction;
 use AndrewDyer\Actions\Exceptions\BadRequestException;
 use AndrewDyer\Actions\Exceptions\ForbiddenException;
 use AndrewDyer\Actions\Exceptions\NotFoundException;
+use AndrewDyer\Actions\Exceptions\NotImplementedException;
 use AndrewDyer\Actions\Payloads\ActionPayload;
 use JsonException;
 use PHPUnit\Framework\TestCase;
@@ -226,5 +227,37 @@ final class AbstractActionTest extends TestCase
         self::assertArrayNotHasKey('data', $decoded);
         self::assertSame('RESOURCE_NOT_FOUND', $decoded['error']['type'] ?? null);
         self::assertSame('User not found', $decoded['error']['description'] ?? null);
+    }
+
+    /**
+     * Asserts that NotImplementedException is caught and returns a 501 JSON response.
+     */
+    public function testCatchesNotImplementedException(): void
+    {
+        $serverRequestFactory = new ServerRequestFactory();
+        $request = $serverRequestFactory->createServerRequest('POST', '/payments/refund');
+
+        $responseFactory = new ResponseFactory();
+        $response = $responseFactory->createResponse();
+
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                throw new NotImplementedException('Refunds are not yet supported');
+            }
+        };
+
+        $result = $action($request, $response, []);
+
+        self::assertSame(501, $result->getStatusCode());
+        self::assertSame('application/json; charset=utf-8', $result->getHeaderLine('Content-Type'));
+
+        $body = (string)$result->getBody();
+        $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('error', $decoded);
+        self::assertArrayNotHasKey('data', $decoded);
+        self::assertSame('NOT_IMPLEMENTED', $decoded['error']['type'] ?? null);
+        self::assertSame('Refunds are not yet supported', $decoded['error']['description'] ?? null);
     }
 }

--- a/tests/AbstractActionTest.php
+++ b/tests/AbstractActionTest.php
@@ -7,6 +7,7 @@ namespace AndrewDyer\Actions\Tests;
 use AndrewDyer\Actions\AbstractAction;
 use AndrewDyer\Actions\Exceptions\BadRequestException;
 use AndrewDyer\Actions\Exceptions\ForbiddenException;
+use AndrewDyer\Actions\Exceptions\NotFoundException;
 use AndrewDyer\Actions\Payloads\ActionPayload;
 use JsonException;
 use PHPUnit\Framework\TestCase;
@@ -193,5 +194,37 @@ final class AbstractActionTest extends TestCase
         self::assertArrayNotHasKey('data', $decoded);
         self::assertSame('INSUFFICIENT_PRIVILEGES', $decoded['error']['type'] ?? null);
         self::assertSame('Admin role required', $decoded['error']['description'] ?? null);
+    }
+
+    /**
+     * Asserts that NotFoundException is caught and returns a 404 JSON response.
+     */
+    public function testCatchesNotFoundException(): void
+    {
+        $serverRequestFactory = new ServerRequestFactory();
+        $request = $serverRequestFactory->createServerRequest('GET', '/users/999');
+
+        $responseFactory = new ResponseFactory();
+        $response = $responseFactory->createResponse();
+
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                throw new NotFoundException('User not found');
+            }
+        };
+
+        $result = $action($request, $response, []);
+
+        self::assertSame(404, $result->getStatusCode());
+        self::assertSame('application/json; charset=utf-8', $result->getHeaderLine('Content-Type'));
+
+        $body = (string)$result->getBody();
+        $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('error', $decoded);
+        self::assertArrayNotHasKey('data', $decoded);
+        self::assertSame('RESOURCE_NOT_FOUND', $decoded['error']['type'] ?? null);
+        self::assertSame('User not found', $decoded['error']['description'] ?? null);
     }
 }

--- a/tests/AbstractActionTest.php
+++ b/tests/AbstractActionTest.php
@@ -10,6 +10,7 @@ use AndrewDyer\Actions\Exceptions\ForbiddenException;
 use AndrewDyer\Actions\Exceptions\NotFoundException;
 use AndrewDyer\Actions\Exceptions\NotImplementedException;
 use AndrewDyer\Actions\Exceptions\UnauthenticatedException;
+use AndrewDyer\Actions\Payloads\ActionError;
 use AndrewDyer\Actions\Payloads\ActionPayload;
 use JsonException;
 use PHPUnit\Framework\TestCase;
@@ -162,7 +163,7 @@ final class AbstractActionTest extends TestCase
 
         self::assertArrayHasKey('error', $decoded);
         self::assertArrayNotHasKey('data', $decoded);
-        self::assertSame('BAD_REQUEST', $decoded['error']['type'] ?? null);
+        self::assertSame(ActionError::BAD_REQUEST, $decoded['error']['type'] ?? null);
         self::assertSame('Invalid email format', $decoded['error']['description'] ?? null);
     }
 
@@ -194,7 +195,7 @@ final class AbstractActionTest extends TestCase
 
         self::assertArrayHasKey('error', $decoded);
         self::assertArrayNotHasKey('data', $decoded);
-        self::assertSame('INSUFFICIENT_PRIVILEGES', $decoded['error']['type'] ?? null);
+        self::assertSame(ActionError::INSUFFICIENT_PRIVILEGES, $decoded['error']['type'] ?? null);
         self::assertSame('Admin role required', $decoded['error']['description'] ?? null);
     }
 
@@ -226,7 +227,7 @@ final class AbstractActionTest extends TestCase
 
         self::assertArrayHasKey('error', $decoded);
         self::assertArrayNotHasKey('data', $decoded);
-        self::assertSame('RESOURCE_NOT_FOUND', $decoded['error']['type'] ?? null);
+        self::assertSame(ActionError::RESOURCE_NOT_FOUND, $decoded['error']['type'] ?? null);
         self::assertSame('User not found', $decoded['error']['description'] ?? null);
     }
 
@@ -258,7 +259,7 @@ final class AbstractActionTest extends TestCase
 
         self::assertArrayHasKey('error', $decoded);
         self::assertArrayNotHasKey('data', $decoded);
-        self::assertSame('NOT_IMPLEMENTED', $decoded['error']['type'] ?? null);
+        self::assertSame(ActionError::NOT_IMPLEMENTED, $decoded['error']['type'] ?? null);
         self::assertSame('Refunds are not yet supported', $decoded['error']['description'] ?? null);
     }
 
@@ -290,7 +291,7 @@ final class AbstractActionTest extends TestCase
 
         self::assertArrayHasKey('error', $decoded);
         self::assertArrayNotHasKey('data', $decoded);
-        self::assertSame('UNAUTHENTICATED', $decoded['error']['type'] ?? null);
+        self::assertSame(ActionError::UNAUTHENTICATED, $decoded['error']['type'] ?? null);
         self::assertSame('Token expired', $decoded['error']['description'] ?? null);
     }
 
@@ -320,7 +321,7 @@ final class AbstractActionTest extends TestCase
         $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
 
         self::assertArrayHasKey('error', $decoded);
-        self::assertSame('RESOURCE_NOT_FOUND', $decoded['error']['type'] ?? null);
+        self::assertSame(ActionError::RESOURCE_NOT_FOUND, $decoded['error']['type'] ?? null);
         self::assertArrayNotHasKey('description', $decoded['error']);
     }
 
@@ -350,7 +351,7 @@ final class AbstractActionTest extends TestCase
         $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
 
         self::assertArrayHasKey('error', $decoded);
-        self::assertSame('RESOURCE_NOT_FOUND', $decoded['error']['type'] ?? null);
+        self::assertSame(ActionError::RESOURCE_NOT_FOUND, $decoded['error']['type'] ?? null);
         self::assertSame('0', $decoded['error']['description'] ?? null);
     }
 }

--- a/tests/AbstractActionTest.php
+++ b/tests/AbstractActionTest.php
@@ -323,4 +323,34 @@ final class AbstractActionTest extends TestCase
         self::assertSame('RESOURCE_NOT_FOUND', $decoded['error']['type'] ?? null);
         self::assertArrayNotHasKey('description', $decoded['error']);
     }
+
+    /**
+     * Asserts that exceptions with "0" as message preserve it (not treated as falsy).
+     */
+    public function testCatchesExceptionWithZeroMessage(): void
+    {
+        $serverRequestFactory = new ServerRequestFactory();
+        $request = $serverRequestFactory->createServerRequest('GET', '/items/0');
+
+        $responseFactory = new ResponseFactory();
+        $response = $responseFactory->createResponse();
+
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                throw new NotFoundException('0');
+            }
+        };
+
+        $result = $action($request, $response, []);
+
+        self::assertSame(404, $result->getStatusCode());
+
+        $body = (string)$result->getBody();
+        $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('error', $decoded);
+        self::assertSame('RESOURCE_NOT_FOUND', $decoded['error']['type'] ?? null);
+        self::assertSame('0', $decoded['error']['description'] ?? null);
+    }
 }

--- a/tests/AbstractActionTest.php
+++ b/tests/AbstractActionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AndrewDyer\Actions\Tests;
 
 use AndrewDyer\Actions\AbstractAction;
+use AndrewDyer\Actions\Exceptions\BadRequestException;
 use AndrewDyer\Actions\Payloads\ActionPayload;
 use JsonException;
 use PHPUnit\Framework\TestCase;
@@ -127,5 +128,37 @@ final class AbstractActionTest extends TestCase
         $this->expectException(JsonException::class);
 
         $action($request, $response, []);
+    }
+
+    /**
+     * Asserts that BadRequestException is caught and returns a 400 JSON response.
+     */
+    public function testCatchesBadRequestException(): void
+    {
+        $serverRequestFactory = new ServerRequestFactory();
+        $request = $serverRequestFactory->createServerRequest('POST', '/invalid');
+
+        $responseFactory = new ResponseFactory();
+        $response = $responseFactory->createResponse();
+
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                throw new BadRequestException('Invalid email format');
+            }
+        };
+
+        $result = $action($request, $response, []);
+
+        self::assertSame(400, $result->getStatusCode());
+        self::assertSame('application/json; charset=utf-8', $result->getHeaderLine('Content-Type'));
+
+        $body = (string)$result->getBody();
+        $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('error', $decoded);
+        self::assertArrayNotHasKey('data', $decoded);
+        self::assertSame('BAD_REQUEST', $decoded['error']['type'] ?? null);
+        self::assertSame('Invalid email format', $decoded['error']['description'] ?? null);
     }
 }

--- a/tests/AbstractActionTest.php
+++ b/tests/AbstractActionTest.php
@@ -293,4 +293,34 @@ final class AbstractActionTest extends TestCase
         self::assertSame('UNAUTHENTICATED', $decoded['error']['type'] ?? null);
         self::assertSame('Token expired', $decoded['error']['description'] ?? null);
     }
+
+    /**
+     * Asserts that exceptions with empty messages use null descriptions.
+     */
+    public function testCatchesExceptionWithEmptyMessage(): void
+    {
+        $serverRequestFactory = new ServerRequestFactory();
+        $request = $serverRequestFactory->createServerRequest('GET', '/users/999');
+
+        $responseFactory = new ResponseFactory();
+        $response = $responseFactory->createResponse();
+
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                throw new NotFoundException();
+            }
+        };
+
+        $result = $action($request, $response, []);
+
+        self::assertSame(404, $result->getStatusCode());
+
+        $body = (string)$result->getBody();
+        $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('error', $decoded);
+        self::assertSame('RESOURCE_NOT_FOUND', $decoded['error']['type'] ?? null);
+        self::assertArrayNotHasKey('description', $decoded['error']);
+    }
 }

--- a/tests/AbstractActionTest.php
+++ b/tests/AbstractActionTest.php
@@ -9,6 +9,7 @@ use AndrewDyer\Actions\Exceptions\BadRequestException;
 use AndrewDyer\Actions\Exceptions\ForbiddenException;
 use AndrewDyer\Actions\Exceptions\NotFoundException;
 use AndrewDyer\Actions\Exceptions\NotImplementedException;
+use AndrewDyer\Actions\Exceptions\UnauthenticatedException;
 use AndrewDyer\Actions\Payloads\ActionPayload;
 use JsonException;
 use PHPUnit\Framework\TestCase;
@@ -259,5 +260,37 @@ final class AbstractActionTest extends TestCase
         self::assertArrayNotHasKey('data', $decoded);
         self::assertSame('NOT_IMPLEMENTED', $decoded['error']['type'] ?? null);
         self::assertSame('Refunds are not yet supported', $decoded['error']['description'] ?? null);
+    }
+
+    /**
+     * Asserts that UnauthenticatedException is caught and returns a 401 JSON response.
+     */
+    public function testCatchesUnauthenticatedException(): void
+    {
+        $serverRequestFactory = new ServerRequestFactory();
+        $request = $serverRequestFactory->createServerRequest('GET', '/protected');
+
+        $responseFactory = new ResponseFactory();
+        $response = $responseFactory->createResponse();
+
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                throw new UnauthenticatedException('Token expired');
+            }
+        };
+
+        $result = $action($request, $response, []);
+
+        self::assertSame(401, $result->getStatusCode());
+        self::assertSame('application/json; charset=utf-8', $result->getHeaderLine('Content-Type'));
+
+        $body = (string)$result->getBody();
+        $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('error', $decoded);
+        self::assertArrayNotHasKey('data', $decoded);
+        self::assertSame('UNAUTHENTICATED', $decoded['error']['type'] ?? null);
+        self::assertSame('Token expired', $decoded['error']['description'] ?? null);
     }
 }

--- a/tests/AbstractActionTest.php
+++ b/tests/AbstractActionTest.php
@@ -6,6 +6,7 @@ namespace AndrewDyer\Actions\Tests;
 
 use AndrewDyer\Actions\AbstractAction;
 use AndrewDyer\Actions\Exceptions\BadRequestException;
+use AndrewDyer\Actions\Exceptions\ForbiddenException;
 use AndrewDyer\Actions\Payloads\ActionPayload;
 use JsonException;
 use PHPUnit\Framework\TestCase;
@@ -160,5 +161,37 @@ final class AbstractActionTest extends TestCase
         self::assertArrayNotHasKey('data', $decoded);
         self::assertSame('BAD_REQUEST', $decoded['error']['type'] ?? null);
         self::assertSame('Invalid email format', $decoded['error']['description'] ?? null);
+    }
+
+    /**
+     * Asserts that ForbiddenException is caught and returns a 403 JSON response.
+     */
+    public function testCatchesForbiddenException(): void
+    {
+        $serverRequestFactory = new ServerRequestFactory();
+        $request = $serverRequestFactory->createServerRequest('DELETE', '/admin/users/1');
+
+        $responseFactory = new ResponseFactory();
+        $response = $responseFactory->createResponse();
+
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                throw new ForbiddenException('Admin role required');
+            }
+        };
+
+        $result = $action($request, $response, []);
+
+        self::assertSame(403, $result->getStatusCode());
+        self::assertSame('application/json; charset=utf-8', $result->getHeaderLine('Content-Type'));
+
+        $body = (string)$result->getBody();
+        $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('error', $decoded);
+        self::assertArrayNotHasKey('data', $decoded);
+        self::assertSame('INSUFFICIENT_PRIVILEGES', $decoded['error']['type'] ?? null);
+        self::assertSame('Admin role required', $decoded['error']['description'] ?? null);
     }
 }

--- a/tests/Concerns/RespondsWithJsonTest.php
+++ b/tests/Concerns/RespondsWithJsonTest.php
@@ -141,7 +141,9 @@ final class RespondsWithJsonTest extends TestCase
         $response = $this->dispatch($action);
 
         self::assertSame(400, $response->getStatusCode());
-        self::assertNull($this->decodeBody($response)['error']['description']);
+
+        $body = $this->decodeBody($response);
+        self::assertArrayNotHasKey('description', $body['error']);
     }
 
     /**
@@ -163,6 +165,26 @@ final class RespondsWithJsonTest extends TestCase
     }
 
     /**
+     * Asserts that unauthorized method accepts a null description.
+     */
+    public function testUnauthorizedAcceptsNullDescription(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->unauthorized();
+            }
+        };
+
+        $response = $this->dispatch($action);
+
+        self::assertSame(401, $response->getStatusCode());
+
+        $body = $this->decodeBody($response);
+        self::assertArrayNotHasKey('description', $body['error']);
+    }
+
+    /**
      * Asserts that forbidden method returns 403 with an INSUFFICIENT_PRIVILEGES error type.
      */
     public function testForbiddenReturns403(): void
@@ -178,6 +200,26 @@ final class RespondsWithJsonTest extends TestCase
 
         self::assertSame(403, $response->getStatusCode());
         self::assertSame(ActionError::INSUFFICIENT_PRIVILEGES, $this->decodeBody($response)['error']['type']);
+    }
+
+    /**
+     * Asserts that forbidden method accepts a null description.
+     */
+    public function testForbiddenAcceptsNullDescription(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->forbidden();
+            }
+        };
+
+        $response = $this->dispatch($action);
+
+        self::assertSame(403, $response->getStatusCode());
+
+        $body = $this->decodeBody($response);
+        self::assertArrayNotHasKey('description', $body['error']);
     }
 
     /**
@@ -199,6 +241,26 @@ final class RespondsWithJsonTest extends TestCase
     }
 
     /**
+     * Asserts that notFound method accepts a null description.
+     */
+    public function testNotFoundAcceptsNullDescription(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->notFound();
+            }
+        };
+
+        $response = $this->dispatch($action);
+
+        self::assertSame(404, $response->getStatusCode());
+
+        $body = $this->decodeBody($response);
+        self::assertArrayNotHasKey('description', $body['error']);
+    }
+
+    /**
      * Asserts that notAllowed method returns 405 with a NOT_ALLOWED error type.
      */
     public function testNotAllowedReturns405(): void
@@ -214,6 +276,26 @@ final class RespondsWithJsonTest extends TestCase
 
         self::assertSame(405, $response->getStatusCode());
         self::assertSame(ActionError::NOT_ALLOWED, $this->decodeBody($response)['error']['type']);
+    }
+
+    /**
+     * Asserts that notAllowed method accepts a null description.
+     */
+    public function testNotAllowedAcceptsNullDescription(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->notAllowed();
+            }
+        };
+
+        $response = $this->dispatch($action);
+
+        self::assertSame(405, $response->getStatusCode());
+
+        $body = $this->decodeBody($response);
+        self::assertArrayNotHasKey('description', $body['error']);
     }
 
     /**
@@ -235,6 +317,26 @@ final class RespondsWithJsonTest extends TestCase
     }
 
     /**
+     * Asserts that notImplemented method accepts a null description.
+     */
+    public function testNotImplementedAcceptsNullDescription(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->notImplemented();
+            }
+        };
+
+        $response = $this->dispatch($action);
+
+        self::assertSame(501, $response->getStatusCode());
+
+        $body = $this->decodeBody($response);
+        self::assertArrayNotHasKey('description', $body['error']);
+    }
+
+    /**
      * Asserts that serverError method returns 500 with a SERVER_ERROR error type.
      */
     public function testServerErrorReturns500(): void
@@ -250,5 +352,25 @@ final class RespondsWithJsonTest extends TestCase
 
         self::assertSame(500, $response->getStatusCode());
         self::assertSame(ActionError::SERVER_ERROR, $this->decodeBody($response)['error']['type']);
+    }
+
+    /**
+     * Asserts that serverError method accepts a null description.
+     */
+    public function testServerErrorAcceptsNullDescription(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->serverError();
+            }
+        };
+
+        $response = $this->dispatch($action);
+
+        self::assertSame(500, $response->getStatusCode());
+
+        $body = $this->decodeBody($response);
+        self::assertArrayNotHasKey('description', $body['error']);
     }
 }

--- a/tests/Concerns/RespondsWithJsonTest.php
+++ b/tests/Concerns/RespondsWithJsonTest.php
@@ -161,7 +161,9 @@ final class RespondsWithJsonTest extends TestCase
         $response = $this->dispatch($action);
 
         self::assertSame(401, $response->getStatusCode());
-        self::assertSame(ActionError::UNAUTHENTICATED, $this->decodeBody($response)['error']['type']);
+
+        $body = $this->decodeBody($response);
+        self::assertSame(ActionError::UNAUTHENTICATED, $body['error']['type']);
     }
 
     /**
@@ -199,7 +201,9 @@ final class RespondsWithJsonTest extends TestCase
         $response = $this->dispatch($action);
 
         self::assertSame(403, $response->getStatusCode());
-        self::assertSame(ActionError::INSUFFICIENT_PRIVILEGES, $this->decodeBody($response)['error']['type']);
+
+        $body = $this->decodeBody($response);
+        self::assertSame(ActionError::INSUFFICIENT_PRIVILEGES, $body['error']['type']);
     }
 
     /**
@@ -237,7 +241,9 @@ final class RespondsWithJsonTest extends TestCase
         $response = $this->dispatch($action);
 
         self::assertSame(404, $response->getStatusCode());
-        self::assertSame(ActionError::RESOURCE_NOT_FOUND, $this->decodeBody($response)['error']['type']);
+
+        $body = $this->decodeBody($response);
+        self::assertSame(ActionError::RESOURCE_NOT_FOUND, $body['error']['type']);
     }
 
     /**
@@ -275,7 +281,9 @@ final class RespondsWithJsonTest extends TestCase
         $response = $this->dispatch($action);
 
         self::assertSame(405, $response->getStatusCode());
-        self::assertSame(ActionError::NOT_ALLOWED, $this->decodeBody($response)['error']['type']);
+
+        $body = $this->decodeBody($response);
+        self::assertSame(ActionError::NOT_ALLOWED, $body['error']['type']);
     }
 
     /**
@@ -313,7 +321,9 @@ final class RespondsWithJsonTest extends TestCase
         $response = $this->dispatch($action);
 
         self::assertSame(501, $response->getStatusCode());
-        self::assertSame(ActionError::NOT_IMPLEMENTED, $this->decodeBody($response)['error']['type']);
+
+        $body = $this->decodeBody($response);
+        self::assertSame(ActionError::NOT_IMPLEMENTED, $body['error']['type']);
     }
 
     /**
@@ -351,7 +361,9 @@ final class RespondsWithJsonTest extends TestCase
         $response = $this->dispatch($action);
 
         self::assertSame(500, $response->getStatusCode());
-        self::assertSame(ActionError::SERVER_ERROR, $this->decodeBody($response)['error']['type']);
+
+        $body = $this->decodeBody($response);
+        self::assertSame(ActionError::SERVER_ERROR, $body['error']['type']);
     }
 
     /**

--- a/tests/Payloads/ActionErrorTest.php
+++ b/tests/Payloads/ActionErrorTest.php
@@ -61,7 +61,6 @@ final class ActionErrorTest extends TestCase
         self::assertSame(
             [
                 'type' => ActionError::RESOURCE_NOT_FOUND,
-                'description' => null,
             ],
             $error->jsonSerialize()
         );


### PR DESCRIPTION
This pull request introduces a structured exception handling mechanism for domain errors in actions, along with improved documentation and minor payload serialization changes. The main focus is on allowing domain-specific exceptions to be thrown in action handlers, which are then automatically mapped to appropriate HTTP responses (e.g., 400, 401, 403, 404, 501), decoupling business logic from HTTP concerns.

**Exception Handling Integration:**

* [`src/AbstractAction.php`](diffhunk://#diff-116fe25fa78509c6571a37859b540883047cba7eb993aa7e7b36283849a8ace7R60-R72): Adds try/catch logic to automatically catch and map domain exceptions implementing new marker interfaces to corresponding JSON error responses (400, 401, 403, 404, 501).
* Introduces new marker interfaces for exception types: `BadRequestExceptionInterface`, `UnauthenticatedExceptionInterface`, `ForbiddenExceptionInterface`, `NotFoundExceptionInterface`, and `NotImplementedExceptionInterface` in `src/Contracts/`. [[1]](diffhunk://#diff-57eeb6a2ca358bb6cd22a3a127a36586ed3f27a033b82f9d3812395101eaf999R1-R21) [[2]](diffhunk://#diff-8d59049063b2e19762671626cbecf53f775664d2a97a00b91bd5421272b56fbbR1-R21) [[3]](diffhunk://#diff-08be2d36312a4cf3b89e2574a8da272349443cf2f53433489cf60ae01ae10760R1-R21) [[4]](diffhunk://#diff-cba0afbf73f860b342491d0ceee97814066a80ee3b6ea0b63db1155fadbb5e73R1-R21) [[5]](diffhunk://#diff-e29d095df3e7087ca6dc3f3e2b150474bd6c89a8a94e119dbf0ecd4481acaefdR1-R21)
* Provides concrete base exception classes in `src/Exceptions/` for each error type, intended for extension in domain code. [[1]](diffhunk://#diff-4853c131ab51a345c646baf1cf3f78bce36379983c6b851d8dca447674586c61R1-R21) [[2]](diffhunk://#diff-a7490b8f9edf6f42775ece0147c63704f8f942816b7df4d831f092c9b0f00631R1-R21) [[3]](diffhunk://#diff-aa5c98b1effadfcf6124e79302a197e0aa547d0cd396f90c9a1515665d57add3R1-R21) [[4]](diffhunk://#diff-aace522c9ce6d81939aa05b6c07e3265eb0531ba487a1799540073a44c460b63R1-R21) [[5]](diffhunk://#diff-4eee4053774800ddad390c4dd097bb96ef38145793797082900bd0acd8f8e437R1-R21)

**Documentation Updates:**

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L37-R37): Updates the usage example to demonstrate the new exception handling flow, including how to throw and handle domain exceptions, and documents the new exception types and their mapping to HTTP responses. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L37-R37) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L47-R97) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L98-R116) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L116-R194)

**Payload Serialization:**

* [`src/Payloads/AbstractActionError.php`](diffhunk://#diff-2d520453b3d08f601d3f416eb2325b97ba8b78d2a3821b8ee4633e0233091343L51-R61): Changes JSON serialization so that the `description` field is omitted when null, resulting in cleaner error payloads.

**Testing Support:**

* [`tests/AbstractActionTest.php`](diffhunk://#diff-9aee27bf40a1de5c43d3e4a2f820b75e20d4a3fe339f9dcdf5bbdf96df1b6dafR8-R12): Adds imports for the new exception classes to facilitate testing of the new exception handling behavior.

These changes make it easier to write clean, decoupled action handlers that communicate errors through exceptions, with automatic, consistent HTTP error responses.