### PR TITLE
feat: :sparkles: add query parameter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Helper methods are available for accessing request data in a consistent and pred
 Query parameters from the request URI can be accessed using two methods:
 
 - **`getQueryParams(): array`** — Returns all query parameters as an associative array
-- **`resolveQueryParam(string $name, mixed $default = self::REQUIRED): mixed`** — Retrieves a query parameter by name. If a default value is provided, the parameter is optional and the default is returned when missing. If no default value is provided, the parameter is required and a RuntimeException is thrown when missing.
+- **`resolveQueryParam(string $name, mixed $default = null): mixed`** — Retrieves a query parameter by name. If a default value is provided, the parameter is optional and the default is returned when missing. If no default value is provided, the parameter is required and a RuntimeException is thrown when missing.
 
 ### Example: Pagination and filtering
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Accept: application/json
 
 ### Example: Array query parameters
 
-Query parameters may also contain array values (for example, `?tags[]=foo&tags[]=bar`):
+Query parameters may also contain array values (for example, `?tags[]=foo&tags[]=bar&tags[]=baz`):
 
 ```php
 protected function handle(): ResponseInterface

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Helper methods are available for accessing request data in a consistent and pred
 Query parameters from the request URI can be accessed using two methods:
 
 - **`getQueryParams(): array`** — Returns all query parameters as an associative array
-- **`resolveQueryParam(string $name): string|array`** — Retrieves a specific query parameter by name, throwing a `RuntimeException` if the parameter is not present
+- **`resolveQueryParam(string $name, mixed $default = self::REQUIRED): mixed`** — Retrieves a query parameter by name. If a default value is provided, the parameter is optional and the default is returned when missing. If no default value is provided, the parameter is required and a RuntimeException is thrown when missing.
 
 ### Example: Pagination and filtering
 
@@ -190,15 +190,12 @@ final class ListProductsAction extends AbstractAction
 {
     protected function handle(): ResponseInterface
     {
-        // Get all query parameters
-        $queryParams = $this->getQueryParams();
-
-        // Resolve specific required parameters
+        // Required parameter (throws exception if missing)
         $category = $this->resolveQueryParam('category');
 
         // Optional parameters with defaults
-        $page = $queryParams['page'] ?? 1;
-        $limit = $queryParams['limit'] ?? 20;
+        $page = $this->resolveQueryParam('page', 1);
+        $limit = $this->resolveQueryParam('limit', 20);
 
         // Your domain logic here...
         $products = $this->fetchProducts($category, (int) $page, (int) $limit);

--- a/README.md
+++ b/README.md
@@ -165,6 +165,93 @@ Helper methods provided by `AbstractAction` generate structured JSON responses. 
 
 For full control over the payload, call `json(ActionPayloadInterface $payload)` directly.
 
+## Request helpers
+
+Helper methods are available for accessing request data in a consistent and predictable manner.
+
+### Query parameters
+
+Query parameters from the request URI can be accessed using two methods:
+
+- **`getQueryParams(): array`** — Returns all query parameters as an associative array
+- **`resolveQueryParam(string $name): string|array`** — Retrieves a specific query parameter by name, throwing a `RuntimeException` if the parameter is not present
+
+### Example: Pagination and filtering
+
+```php
+declare(strict_types=1);
+
+namespace App\Http\Actions;
+
+use AndrewDyer\Actions\AbstractAction;
+use Psr\Http\Message\ResponseInterface;
+
+final class ListProductsAction extends AbstractAction
+{
+    protected function handle(): ResponseInterface
+    {
+        // Get all query parameters
+        $queryParams = $this->getQueryParams();
+
+        // Resolve specific required parameters
+        $category = $this->resolveQueryParam('category');
+
+        // Optional parameters with defaults
+        $page = $queryParams['page'] ?? 1;
+        $limit = $queryParams['limit'] ?? 20;
+
+        // Your domain logic here...
+        $products = $this->fetchProducts($category, (int) $page, (int) $limit);
+
+        return $this->ok([
+            'products' => $products,
+            'pagination' => [
+                'page' => (int) $page,
+                'limit' => (int) $limit,
+            ],
+        ]);
+    }
+}
+```
+
+**Request**
+
+```
+GET /products?category=electronics&page=2&limit=10
+Accept: application/json
+```
+
+**Response: 200 OK**
+
+```json
+{
+  "data": {
+    "products": [...],
+    "pagination": {
+      "page": 2,
+      "limit": 10
+    }
+  }
+}
+```
+
+### Example: Array query parameters
+
+Query parameters may also contain array values (for example, `?tags[]=foo&tags[]=bar`):
+
+```php
+protected function handle(): ResponseInterface
+{
+    // Resolves to ['foo', 'bar', 'baz']
+    $tags = $this->resolveQueryParam('tags');
+
+    // Your domain logic here...
+    $items = $this->findByTags($tags);
+
+    return $this->ok(['items' => $items]);
+}
+```
+
 ## Exception handling
 
 Domain exceptions are caught automatically by `AbstractAction` and mapped to appropriate HTTP responses. This is useful when exceptions are thrown from services, repositories, or other domain logic that should not be coupled to HTTP concerns. Extend the base exception classes to create domain-specific exceptions.

--- a/src/AbstractAction.php
+++ b/src/AbstractAction.php
@@ -25,6 +25,11 @@ abstract class AbstractAction
     use RespondsWithJson;
 
     /**
+     * Sentinel value used to indicate a required query parameter.
+     */
+    private const string REQUIRED = '__REQUIRED__';
+
+    /**
      * Route arguments resolved from the matched URL pattern.
      */
     private array $args = [];
@@ -142,20 +147,26 @@ abstract class AbstractAction
     }
 
     /**
-     * Resolves a required query parameter by name.
+     * Retrieves a query parameter by name with optional default fallback.
      *
-     * @param string $name The name of the query parameter to retrieve.
+     * @param string $name    The name of the query parameter to retrieve.
+     * @param mixed  $default The value to return if the parameter is absent.
+     *                        If omitted, the parameter is treated as required and a RuntimeException is thrown when missing.
      *
-     * @throws RuntimeException When the parameter is absent from the query string.
+     * @throws RuntimeException When the parameter is absent and no default is provided.
      *
-     * @return string|array The resolved query parameter value.
+     * @return mixed The query parameter value if present, or the default value otherwise.
      */
-    protected function resolveQueryParam(string $name): string|array
+    protected function resolveQueryParam(string $name, mixed $default = self::REQUIRED): mixed
     {
-        $params = $this->request->getQueryParams();
+        $params = $this->getQueryParams();
 
         if (!array_key_exists($name, $params)) {
-            throw new RuntimeException("Missing query parameter: {$name}");
+            if ($default === self::REQUIRED) {
+                throw new RuntimeException("Missing query parameter: {$name}");
+            }
+
+            return $default;
         }
 
         return $params[$name];

--- a/src/AbstractAction.php
+++ b/src/AbstractAction.php
@@ -114,6 +114,16 @@ abstract class AbstractAction
     }
 
     /**
+     * Returns the query parameters from the request URI.
+     *
+     * @return array The decoded key-value pairs from the query string.
+     */
+    protected function getQueryParams(): array
+    {
+        return $this->request->getQueryParams();
+    }
+
+    /**
      * Resolves a required route argument by name.
      *
      * @param string $name The name of the route argument to retrieve.
@@ -129,6 +139,26 @@ abstract class AbstractAction
         }
 
         return $this->args[$name];
+    }
+
+    /**
+     * Resolves a required query parameter by name.
+     *
+     * @param string $name The name of the query parameter to retrieve.
+     *
+     * @throws RuntimeException When the parameter is absent from the query string.
+     *
+     * @return string|array The resolved query parameter value.
+     */
+    protected function resolveQueryParam(string $name): string|array
+    {
+        $params = $this->request->getQueryParams();
+
+        if (!array_key_exists($name, $params)) {
+            throw new RuntimeException("Missing query parameter: {$name}");
+        }
+
+        return $params[$name];
     }
 
     /**

--- a/src/AbstractAction.php
+++ b/src/AbstractAction.php
@@ -25,11 +25,6 @@ abstract class AbstractAction
     use RespondsWithJson;
 
     /**
-     * Sentinel value used to indicate a required query parameter.
-     */
-    private const string REQUIRED = '__REQUIRED__';
-
-    /**
      * Route arguments resolved from the matched URL pattern.
      */
     private array $args = [];
@@ -151,18 +146,20 @@ abstract class AbstractAction
      *
      * @param string $name    The name of the query parameter to retrieve.
      * @param mixed  $default The value to return if the parameter is absent.
-     *                        If omitted, the parameter is treated as required and a RuntimeException is thrown when missing.
+     *                        If omitted entirely, the parameter is treated as required
+     *                        and a RuntimeException is thrown when missing. Explicitly
+     *                        passing null is valid and will be returned as the default.
      *
+     * @return mixed            The query parameter value if present, or the default value otherwise.
      * @throws RuntimeException When the parameter is absent and no default is provided.
-     *
-     * @return mixed The query parameter value if present, or the default value otherwise.
      */
-    protected function resolveQueryParam(string $name, mixed $default = self::REQUIRED): mixed
+    protected function resolveQueryParam(string $name, mixed $default = null): mixed
     {
         $params = $this->getQueryParams();
+        $missing = !array_key_exists($name, $params);
 
-        if (!array_key_exists($name, $params)) {
-            if ($default === self::REQUIRED) {
+        if ($missing) {
+            if (func_num_args() < 2) {
                 throw new RuntimeException("Missing query parameter: {$name}");
             }
 

--- a/tests/AbstractActionTest.php
+++ b/tests/AbstractActionTest.php
@@ -425,7 +425,7 @@ final class AbstractActionTest extends TestCase
     }
 
     /**
-     * Asserts that resolveQueryParam successfully retrieves a query parameter.
+     * Asserts that resolveQueryParam successfully retrieves a required query parameter.
      */
     public function testResolveQueryParamReturnsParameter(): void
     {
@@ -461,7 +461,7 @@ final class AbstractActionTest extends TestCase
     }
 
     /**
-     * Asserts that resolveQueryParam throws when the parameter is absent.
+     * Asserts that resolveQueryParam throws when the parameter is absent and no default is provided.
      */
     public function testResolveQueryParamThrowsWhenMissing(): void
     {
@@ -516,5 +516,143 @@ final class AbstractActionTest extends TestCase
         self::assertArrayHasKey('data', $decoded);
         self::assertIsArray($decoded['data']['tags']);
         self::assertSame(['foo', 'bar', 'baz'], $decoded['data']['tags']);
+    }
+
+    /**
+     * Asserts that resolveQueryParam returns an existing optional query parameter.
+     */
+    public function testResolveQueryParamReturnsOptionalParameter(): void
+    {
+        $serverRequestFactory = new ServerRequestFactory();
+        $request = $serverRequestFactory->createServerRequest('GET', '/items?page=2&limit=10');
+
+        $responseFactory = new ResponseFactory();
+        $response = $responseFactory->createResponse();
+
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                $page = $this->resolveQueryParam('page', 1);
+                $limit = $this->resolveQueryParam('limit', 20);
+
+                return $this->json(
+                    ActionPayload::success([
+                        'page' => $page,
+                        'limit' => $limit,
+                    ])
+                );
+            }
+        };
+
+        $result = $action($request, $response, []);
+
+        $body = (string)$result->getBody();
+        $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('data', $decoded);
+        self::assertSame('2', $decoded['data']['page']);
+        self::assertSame('10', $decoded['data']['limit']);
+    }
+
+    /**
+     * Asserts that resolveQueryParam returns array values from optional query parameters.
+     */
+    public function testResolveQueryParamReturnsOptionalArrayValues(): void
+    {
+        $serverRequestFactory = new ServerRequestFactory();
+        $request = $serverRequestFactory->createServerRequest('GET', '/items?tags[]=foo&tags[]=bar');
+
+        $responseFactory = new ResponseFactory();
+        $response = $responseFactory->createResponse();
+
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                $tags = $this->resolveQueryParam('tags', []);
+
+                return $this->json(
+                    ActionPayload::success(['tags' => $tags])
+                );
+            }
+        };
+
+        $result = $action($request, $response, []);
+
+        $body = (string)$result->getBody();
+        $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('data', $decoded);
+        self::assertIsArray($decoded['data']['tags']);
+        self::assertSame(['foo', 'bar'], $decoded['data']['tags']);
+    }
+
+    /**
+     * Asserts that resolveQueryParam returns the provided default when parameter is missing.
+     */
+    public function testResolveQueryParamReturnsDefaultWhenMissing(): void
+    {
+        $serverRequestFactory = new ServerRequestFactory();
+        $request = $serverRequestFactory->createServerRequest('GET', '/items');
+
+        $responseFactory = new ResponseFactory();
+        $response = $responseFactory->createResponse();
+
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                $page = $this->resolveQueryParam('page', 1);
+                $limit = $this->resolveQueryParam('limit', 20);
+                $sort = $this->resolveQueryParam('sort', 'asc');
+
+                return $this->json(
+                    ActionPayload::success([
+                        'page' => $page,
+                        'limit' => $limit,
+                        'sort' => $sort,
+                    ])
+                );
+            }
+        };
+
+        $result = $action($request, $response, []);
+
+        $body = (string)$result->getBody();
+        $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('data', $decoded);
+        self::assertSame(1, $decoded['data']['page']);
+        self::assertSame(20, $decoded['data']['limit']);
+        self::assertSame('asc', $decoded['data']['sort']);
+    }
+
+    /**
+     * Asserts that resolveQueryParam returns null when explicitly provided as default.
+     */
+    public function testResolveQueryParamReturnsNullAsExplicitDefault(): void
+    {
+        $serverRequestFactory = new ServerRequestFactory();
+        $request = $serverRequestFactory->createServerRequest('GET', '/items');
+
+        $responseFactory = new ResponseFactory();
+        $response = $responseFactory->createResponse();
+
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                $filter = $this->resolveQueryParam('filter', null);
+
+                return $this->json(
+                    ActionPayload::success(['filter' => $filter])
+                );
+            }
+        };
+
+        $result = $action($request, $response, []);
+
+        $body = (string)$result->getBody();
+        $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('data', $decoded);
+        self::assertNull($decoded['data']['filter']);
     }
 }

--- a/tests/AbstractActionTest.php
+++ b/tests/AbstractActionTest.php
@@ -383,7 +383,7 @@ final class AbstractActionTest extends TestCase
         $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
 
         self::assertArrayHasKey('data', $decoded);
-        self::assertSame(
+        self::assertEquals(
             [
                 'q' => 'test',
                 'page' => '2',

--- a/tests/AbstractActionTest.php
+++ b/tests/AbstractActionTest.php
@@ -354,4 +354,167 @@ final class AbstractActionTest extends TestCase
         self::assertSame(ActionError::RESOURCE_NOT_FOUND, $decoded['error']['type'] ?? null);
         self::assertSame('0', $decoded['error']['description'] ?? null);
     }
+
+    /**
+     * Asserts that getQueryParams returns query parameters from the request.
+     */
+    public function testGetQueryParamsReturnsParameters(): void
+    {
+        $serverRequestFactory = new ServerRequestFactory();
+        $request = $serverRequestFactory->createServerRequest('GET', '/search?q=test&page=2&limit=10');
+
+        $responseFactory = new ResponseFactory();
+        $response = $responseFactory->createResponse();
+
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                $queryParams = $this->getQueryParams();
+
+                return $this->json(
+                    ActionPayload::success(['queryParams' => $queryParams])
+                );
+            }
+        };
+
+        $result = $action($request, $response, []);
+
+        $body = (string)$result->getBody();
+        $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('data', $decoded);
+        self::assertSame(
+            [
+                'q' => 'test',
+                'page' => '2',
+                'limit' => '10',
+            ],
+            $decoded['data']['queryParams']
+        );
+    }
+
+    /**
+     * Asserts that getQueryParams returns an empty array when no query parameters are present.
+     */
+    public function testGetQueryParamsReturnsEmptyArrayWhenNoParameters(): void
+    {
+        $serverRequestFactory = new ServerRequestFactory();
+        $request = $serverRequestFactory->createServerRequest('GET', '/items');
+
+        $responseFactory = new ResponseFactory();
+        $response = $responseFactory->createResponse();
+
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                $queryParams = $this->getQueryParams();
+
+                return $this->json(
+                    ActionPayload::success(['queryParams' => $queryParams])
+                );
+            }
+        };
+
+        $result = $action($request, $response, []);
+
+        $body = (string)$result->getBody();
+        $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('data', $decoded);
+        self::assertSame([], $decoded['data']['queryParams']);
+    }
+
+    /**
+     * Asserts that resolveQueryParam successfully retrieves a query parameter.
+     */
+    public function testResolveQueryParamReturnsParameter(): void
+    {
+        $serverRequestFactory = new ServerRequestFactory();
+        $request = $serverRequestFactory->createServerRequest('GET', '/search?q=test&category=books');
+
+        $responseFactory = new ResponseFactory();
+        $response = $responseFactory->createResponse();
+
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                $query = $this->resolveQueryParam('q');
+                $category = $this->resolveQueryParam('category');
+
+                return $this->json(
+                    ActionPayload::success([
+                        'query' => $query,
+                        'category' => $category,
+                    ])
+                );
+            }
+        };
+
+        $result = $action($request, $response, []);
+
+        $body = (string)$result->getBody();
+        $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('data', $decoded);
+        self::assertSame('test', $decoded['data']['query']);
+        self::assertSame('books', $decoded['data']['category']);
+    }
+
+    /**
+     * Asserts that resolveQueryParam throws when the parameter is absent.
+     */
+    public function testResolveQueryParamThrowsWhenMissing(): void
+    {
+        $serverRequestFactory = new ServerRequestFactory();
+        $request = $serverRequestFactory->createServerRequest('GET', '/search?q=test');
+
+        $responseFactory = new ResponseFactory();
+        $response = $responseFactory->createResponse();
+
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                $this->resolveQueryParam('missing');
+
+                return $this->json(ActionPayload::success([]));
+            }
+        };
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Missing query parameter: missing');
+
+        $action($request, $response, []);
+    }
+
+    /**
+     * Asserts that resolveQueryParam can retrieve array values from query parameters.
+     */
+    public function testResolveQueryParamReturnsArrayValues(): void
+    {
+        $serverRequestFactory = new ServerRequestFactory();
+        $request = $serverRequestFactory->createServerRequest('GET', '/items?tags[]=foo&tags[]=bar&tags[]=baz');
+
+        $responseFactory = new ResponseFactory();
+        $response = $responseFactory->createResponse();
+
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                $tags = $this->resolveQueryParam('tags');
+
+                return $this->json(
+                    ActionPayload::success(['tags' => $tags])
+                );
+            }
+        };
+
+        $result = $action($request, $response, []);
+
+        $body = (string)$result->getBody();
+        $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('data', $decoded);
+        self::assertIsArray($decoded['data']['tags']);
+        self::assertSame(['foo', 'bar', 'baz'], $decoded['data']['tags']);
+    }
 }


### PR DESCRIPTION
This pull request introduces new helper methods for working with HTTP query parameters in actions, along with comprehensive tests and updated documentation. These helpers make it easier and safer to access query parameters, providing both required and optional parameter handling, including support for array values.

The most important changes are:

**New helper methods for query parameters:**

* Added `getQueryParams()` and `resolveQueryParam()` methods to `AbstractAction` for consistent and predictable access to query parameters. `resolveQueryParam()` supports required parameters (throws if missing) and optional parameters with defaults, including array values. [[1]](diffhunk://#diff-116fe25fa78509c6571a37859b540883047cba7eb993aa7e7b36283849a8ace7R27-R31) [[2]](diffhunk://#diff-116fe25fa78509c6571a37859b540883047cba7eb993aa7e7b36283849a8ace7R121-R130) [[3]](diffhunk://#diff-116fe25fa78509c6571a37859b540883047cba7eb993aa7e7b36283849a8ace7R149-R174)

**Testing improvements:**

* Added extensive tests to `AbstractActionTest.php` to cover various scenarios for the new query parameter helpers, including required/optional parameters, array values, missing parameters, and default values.

**Documentation updates:**

* Updated `README.md` with a new section explaining the request helpers, usage examples for pagination/filtering, and handling of array query parameters.