### PR TITLE
feat: :sparkles: add request helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,107 @@ For full control over the payload, call `json(ActionPayloadInterface $payload)` 
 
 Helper methods are available for accessing request data in a consistent and predictable manner.
 
+### Route arguments
+
+Route arguments are extracted from the URL pattern matched by your router (e.g., `/users/{id}`).
+
+- **`getArgs(): array`** — Returns all route arguments as an associative array
+- **`resolveArg(string $name): string|int`** — Retrieves a route argument by name. Throws a RuntimeException if the argument is missing.
+
+#### Example: Fetching a resource by ID
+
+```php
+declare(strict_types=1);
+
+namespace App\Http\Actions;
+
+use AndrewDyer\Actions\AbstractAction;
+use Psr\Http\Message\ResponseInterface;
+
+final class GetOrderAction extends AbstractAction
+{
+    protected function handle(): ResponseInterface
+    {
+        // Extract the order ID from the route
+        $orderId = (int) $this->resolveArg('id');
+
+        // Your domain logic here...
+        $order = $this->fetchOrder($orderId);
+
+        return $this->ok($order);
+    }
+}
+```
+
+**Request:**
+
+```
+GET /orders/12345
+Accept: application/json
+```
+
+### Request body
+
+The request body can be accessed as an associative array using `getParsedBody()`.
+
+- **`getParsedBody(): array`** — Returns the parsed request body as an array. Returns an empty array if no body is present. Throws a RuntimeException if the body cannot be parsed as an array.
+- **`resolveBodyParam(string $name, mixed $default = null): mixed`** — Retrieves a body parameter by name. If a default value is provided, the parameter is optional and the default is returned when missing. If no default value is provided, the parameter is required and a RuntimeException is thrown when missing.
+
+#### Example: Creating a resource
+
+```php
+declare(strict_types=1);
+
+namespace App\Http\Actions;
+
+use AndrewDyer\Actions\AbstractAction;
+use Psr\Http\Message\ResponseInterface;
+
+final class CreateProductAction extends AbstractAction
+{
+    protected function handle(): ResponseInterface
+    {
+        // Required parameters (throw exception if missing)
+        $name = $this->resolveBodyParam('name');
+        $price = $this->resolveBodyParam('price');
+
+        // Optional parameter with default
+        $description = $this->resolveBodyParam('description', 'No description provided');
+
+        // Your domain logic here...
+        $product = $this->createProduct($name, (float) $price, $description);
+
+        return $this->ok($product, 201);
+    }
+}
+```
+
+**Request:**
+
+```
+POST /products
+Accept: application/json
+Content-Type: application/json
+
+{
+  "name": "Wireless Mouse",
+  "price": 29.99
+}
+```
+
+**Response: 201 Created**
+
+```json
+{
+  "data": {
+    "id": 456,
+    "name": "Wireless Mouse",
+    "description": "No description provided",
+    "price": 29.99
+  }
+}
+```
+
 ### Query parameters
 
 Query parameters from the request URI can be accessed using two methods:
@@ -176,7 +277,7 @@ Query parameters from the request URI can be accessed using two methods:
 - **`getQueryParams(): array`** — Returns all query parameters as an associative array
 - **`resolveQueryParam(string $name, mixed $default = null): mixed`** — Retrieves a query parameter by name. If a default value is provided, the parameter is optional and the default is returned when missing. If no default value is provided, the parameter is required and a RuntimeException is thrown when missing.
 
-### Example: Pagination and filtering
+#### Example: Pagination and filtering
 
 ```php
 declare(strict_types=1);
@@ -232,7 +333,7 @@ Accept: application/json
 }
 ```
 
-### Example: Array query parameters
+#### Example: Array query parameters
 
 Query parameters may also contain array values (for example, `?tags[]=foo&tags[]=bar&tags[]=baz`):
 

--- a/src/AbstractAction.php
+++ b/src/AbstractAction.php
@@ -124,6 +124,16 @@ abstract class AbstractAction
     }
 
     /**
+     * Returns the route arguments from the matched URL pattern.
+     *
+     * @return array<string, string|int> The route arguments as key-value pairs.
+     */
+    protected function getArgs(): array
+    {
+        return $this->args;
+    }
+
+    /**
      * Resolves a required route argument by name.
      *
      * @param string $name The name of the route argument to retrieve.

--- a/src/AbstractAction.php
+++ b/src/AbstractAction.php
@@ -152,6 +152,34 @@ abstract class AbstractAction
     }
 
     /**
+     * Retrieves a body parameter by name with optional default fallback.
+     *
+     * @param string $name    The name of the body parameter to retrieve.
+     * @param mixed  $default The value to return if the parameter is absent.
+     *                        If omitted entirely, the parameter is treated as required
+     *                        and a RuntimeException is thrown when missing. Explicitly
+     *                        passing null is valid and will be returned as the default.
+     *
+     * @return mixed            The body parameter value if present, or the default value otherwise.
+     * @throws RuntimeException When the parameter is absent and no default is provided.
+     */
+    protected function resolveBodyParam(string $name, mixed $default = null): mixed
+    {
+        $body = $this->getParsedBody();
+        $missing = !array_key_exists($name, $body);
+
+        if ($missing) {
+            if (func_num_args() < 2) {
+                throw new RuntimeException("Missing body parameter: {$name}");
+            }
+
+            return $default;
+        }
+
+        return $body[$name];
+    }
+
+    /**
      * Retrieves a query parameter by name with optional default fallback.
      *
      * @param string $name    The name of the query parameter to retrieve.

--- a/tests/AbstractActionTest.php
+++ b/tests/AbstractActionTest.php
@@ -117,6 +117,151 @@ final class AbstractActionTest extends TestCase
     }
 
     /**
+     * Asserts that resolveBodyParam successfully retrieves a present required parameter.
+     */
+    public function testResolveBodyParamReturnsParameter(): void
+    {
+        $request = $this->makeRequest('POST', '/products')
+            ->withParsedBody(['name' => 'Laptop', 'price' => 999.99]);
+
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->json(
+                    ActionPayload::success([
+                        'name' => $this->resolveBodyParam('name'),
+                        'price' => $this->resolveBodyParam('price'),
+                    ])
+                );
+            }
+        };
+
+        $result = $action($request, $this->makeResponse(), []);
+
+        self::assertSame(200, $result->getStatusCode());
+
+        $decoded = json_decode((string)$result->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('data', $decoded);
+        self::assertSame('Laptop', $decoded['data']['name']);
+        self::assertSame(999.99, $decoded['data']['price']);
+    }
+
+    /**
+     * Asserts that resolveBodyParam throws when the parameter is absent and no default is provided.
+     */
+    public function testResolveBodyParamThrowsWhenMissing(): void
+    {
+        $request = $this->makeRequest('POST', '/products')
+            ->withParsedBody(['name' => 'Laptop']);
+
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                $this->resolveBodyParam('price');
+
+                return $this->json(ActionPayload::success([]));
+            }
+        };
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Missing body parameter: price');
+
+        $action($request, $this->makeResponse(), []);
+    }
+
+    /**
+     * Asserts that resolveBodyParam returns an existing optional parameter (not the default).
+     */
+    public function testResolveBodyParamReturnsOptionalParameter(): void
+    {
+        $request = $this->makeRequest('POST', '/products')
+            ->withParsedBody(['name' => 'Laptop', 'description' => 'A powerful laptop']);
+
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->json(
+                    ActionPayload::success([
+                        'name' => $this->resolveBodyParam('name'),
+                        'description' => $this->resolveBodyParam('description', ''),
+                    ])
+                );
+            }
+        };
+
+        $result = $action($request, $this->makeResponse(), []);
+
+        self::assertSame(200, $result->getStatusCode());
+
+        $decoded = json_decode((string)$result->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('data', $decoded);
+        self::assertSame('Laptop', $decoded['data']['name']);
+        self::assertSame('A powerful laptop', $decoded['data']['description']);
+    }
+
+    /**
+     * Asserts that resolveBodyParam returns the provided default when the parameter is missing.
+     */
+    public function testResolveBodyParamReturnsDefaultWhenMissing(): void
+    {
+        $request = $this->makeRequest('POST', '/products')
+            ->withParsedBody(['name' => 'Laptop']);
+
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->json(
+                    ActionPayload::success([
+                        'name' => $this->resolveBodyParam('name'),
+                        'description' => $this->resolveBodyParam('description', 'No description provided'),
+                        'inStock' => $this->resolveBodyParam('inStock', true),
+                    ])
+                );
+            }
+        };
+
+        $result = $action($request, $this->makeResponse(), []);
+
+        self::assertSame(200, $result->getStatusCode());
+
+        $decoded = json_decode((string)$result->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('data', $decoded);
+        self::assertSame('Laptop', $decoded['data']['name']);
+        self::assertSame('No description provided', $decoded['data']['description']);
+        self::assertTrue($decoded['data']['inStock']);
+    }
+
+    /**
+     * Asserts that resolveBodyParam returns null when explicitly provided as a default.
+     */
+    public function testResolveBodyParamReturnsNullAsExplicitDefault(): void
+    {
+        $request = $this->makeRequest('POST', '/products')
+            ->withParsedBody(['name' => 'Laptop']);
+
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->json(
+                    ActionPayload::success(['discount' => $this->resolveBodyParam('discount', null)])
+                );
+            }
+        };
+
+        $result = $action($request, $this->makeResponse(), []);
+
+        self::assertSame(200, $result->getStatusCode());
+
+        $decoded = json_decode((string)$result->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('data', $decoded);
+        self::assertNull($decoded['data']['discount']);
+    }
+
+    /**
      * Asserts that getArgs returns route arguments from the matched URL pattern.
      */
     public function testGetArgsReturnsArguments(): void

--- a/tests/AbstractActionTest.php
+++ b/tests/AbstractActionTest.php
@@ -117,6 +117,58 @@ final class AbstractActionTest extends TestCase
     }
 
     /**
+     * Asserts that getArgs returns route arguments from the matched URL pattern.
+     */
+    public function testGetArgsReturnsArguments(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->json(
+                    ActionPayload::success(['args' => $this->getArgs()])
+                );
+            }
+        };
+
+        $result = $action(
+            $this->makeRequest('GET', '/orders/123/items/456'),
+            $this->makeResponse(),
+            ['orderId' => '123', 'itemId' => '456']
+        );
+
+        self::assertSame(200, $result->getStatusCode());
+
+        $decoded = json_decode((string)$result->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('data', $decoded);
+        self::assertSame(['orderId' => '123', 'itemId' => '456'], $decoded['data']['args']);
+    }
+
+    /**
+     * Asserts that getArgs returns an empty array when no route arguments are present.
+     */
+    public function testGetArgsReturnsEmptyArrayWhenNoArguments(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->json(
+                    ActionPayload::success(['args' => $this->getArgs()])
+                );
+            }
+        };
+
+        $result = $action($this->makeRequest('GET', '/items'), $this->makeResponse(), []);
+
+        self::assertSame(200, $result->getStatusCode());
+
+        $decoded = json_decode((string)$result->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('data', $decoded);
+        self::assertSame([], $decoded['data']['args']);
+    }
+
+    /**
      * Asserts that resolveArg throws when the argument is absent.
      */
     public function testResolveArgThrowsWhenMissing(): void


### PR DESCRIPTION
This pull request adds new helper methods for accessing route arguments and request body parameters in `AbstractAction`, along with comprehensive documentation and tests. These improvements make it easier and safer to extract data from incoming HTTP requests in action handlers.

**New helper methods for request data:**

- Added `getArgs()` and `resolveArg()` to retrieve route arguments from matched URL patterns, and documented their usage with examples in `README.md`. [[1]](diffhunk://#diff-116fe25fa78509c6571a37859b540883047cba7eb993aa7e7b36283849a8ace7R126-R135) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R172-R280)
- Added `resolveBodyParam()` to retrieve required or optional parameters from the parsed request body, with support for default values and error handling, and documented its usage with examples. [[1]](diffhunk://#diff-116fe25fa78509c6571a37859b540883047cba7eb993aa7e7b36283849a8ace7R154-R181) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R172-R280)

**Testing improvements:**

- Added extensive unit tests in `AbstractActionTest.php` to verify the behavior of `getArgs()` and `resolveBodyParam()` for required, optional, and defaulted parameters, as well as for missing parameters and explicit `null` defaults.

**Documentation enhancements:**

- Expanded the `README.md` with clear sections and usage examples for route arguments and request body handling, aligning the documentation with the new helper methods. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R172-R280) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L235-R336)

These changes improve developer ergonomics and reduce boilerplate when handling HTTP request data in action classes.