### PR TITLE
feat: :sparkles: add metadata support

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,16 +150,16 @@ Accept: application/json
 
 Helper methods provided by `AbstractAction` generate structured JSON responses. Each builds the appropriate `ActionPayload` and writes it to the response.
 
-| Method                                        | When to use                                      | Status          | Error type                |
-| --------------------------------------------- | ------------------------------------------------ | --------------- | ------------------------- |
-| `ok(mixed $data, int $statusCode = 200)`      | Successful operation with data payload           | 200 (or custom) | —                         |
-| `badRequest(?string $description = null)`     | Request is malformed or violates business rules  | 400             | `BAD_REQUEST`             |
-| `unauthorized(?string $description = null)`   | Request lacks valid authentication credentials   | 401             | `UNAUTHENTICATED`         |
-| `forbidden(?string $description = null)`      | Authenticated caller lacks required permissions  | 403             | `INSUFFICIENT_PRIVILEGES` |
-| `notFound(?string $description = null)`       | Requested resource does not exist                | 404             | `RESOURCE_NOT_FOUND`      |
-| `notAllowed(?string $description = null)`     | HTTP method not allowed for the resource         | 405             | `NOT_ALLOWED`             |
-| `serverError(?string $description = null)`    | Unexpected server error occurred                 | 500             | `SERVER_ERROR`            |
-| `notImplemented(?string $description = null)` | Requested functionality has not been implemented | 501             | `NOT_IMPLEMENTED`         |
+| Method                                                       | When to use                                      | Status          | Error type                |
+| ------------------------------------------------------------ | ------------------------------------------------ | --------------- | ------------------------- |
+| `ok(mixed $data, mixed $meta = null, int $statusCode = 200)` | Successful operation with data payload           | 200 (or custom) | —                         |
+| `badRequest(?string $description = null)`                    | Request is malformed or violates business rules  | 400             | `BAD_REQUEST`             |
+| `unauthorized(?string $description = null)`                  | Request lacks valid authentication credentials   | 401             | `UNAUTHENTICATED`         |
+| `forbidden(?string $description = null)`                     | Authenticated caller lacks required permissions  | 403             | `INSUFFICIENT_PRIVILEGES` |
+| `notFound(?string $description = null)`                      | Requested resource does not exist                | 404             | `RESOURCE_NOT_FOUND`      |
+| `notAllowed(?string $description = null)`                    | HTTP method not allowed for the resource         | 405             | `NOT_ALLOWED`             |
+| `serverError(?string $description = null)`                   | Unexpected server error occurred                 | 500             | `SERVER_ERROR`            |
+| `notImplemented(?string $description = null)`                | Requested functionality has not been implemented | 501             | `NOT_IMPLEMENTED`         |
 
 > **Note:** When the `description` parameter is `null`, the `description` field is omitted entirely from the error response. API consumers should treat `description` as an optional field.
 
@@ -239,7 +239,7 @@ final class CreateProductAction extends AbstractAction
         // Your domain logic here...
         $product = $this->createProduct($name, (float) $price, $description);
 
-        return $this->ok($product, 201);
+        return $this->ok($product, null, 201);
     }
 }
 ```
@@ -300,14 +300,17 @@ final class ListProductsAction extends AbstractAction
 
         // Your domain logic here...
         $products = $this->fetchProducts($category, (int) $page, (int) $limit);
+        $total = $this->countProducts($category);
 
-        return $this->ok([
-            'products' => $products,
-            'pagination' => [
+        return $this->ok(
+            $products,
+            [
+                'total' => $total,
                 'page' => (int) $page,
-                'limit' => (int) $limit,
-            ],
-        ]);
+                'perPage' => (int) $limit,
+                'totalPages' => (int) ceil($total / $limit),
+            ]
+        );
     }
 }
 ```
@@ -323,12 +326,12 @@ Accept: application/json
 
 ```json
 {
-  "data": {
-    "products": [...],
-    "pagination": {
-      "page": 2,
-      "limit": 10
-    }
+  "data": [...],
+  "meta": {
+    "total": 156,
+    "page": 2,
+    "perPage": 10,
+    "totalPages": 16
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -295,19 +295,19 @@ final class ListProductsAction extends AbstractAction
         $category = $this->resolveQueryParam('category');
 
         // Optional parameters with defaults
-        $page = $this->resolveQueryParam('page', 1);
-        $limit = $this->resolveQueryParam('limit', 20);
+        $page = max(1, (int) $this->resolveQueryParam('page', 1));
+        $limit = max(1, (int) $this->resolveQueryParam('limit', 20));
 
         // Your domain logic here...
-        $products = $this->fetchProducts($category, (int) $page, (int) $limit);
+        $products = $this->fetchProducts($category, $page, $limit);
         $total = $this->countProducts($category);
 
         return $this->ok(
             $products,
             [
                 'total' => $total,
-                'page' => (int) $page,
-                'perPage' => (int) $limit,
+                'page' => $page,
+                'perPage' => $limit,
                 'totalPages' => (int) ceil($total / $limit),
             ]
         );

--- a/src/Concerns/RespondsWithJson.php
+++ b/src/Concerns/RespondsWithJson.php
@@ -44,15 +44,16 @@ trait RespondsWithJson
      * Responds with a 200 OK JSON payload containing the given data.
      *
      * @param mixed $data       The response data to include in the payload.
+     * @param mixed $meta       Optional metadata to include alongside the data.
      * @param int   $statusCode The HTTP status code, defaults to 200.
      *
      * @throws JsonException When the payload cannot be JSON-encoded.
      *
      * @return ResponseInterface The JSON response.
      */
-    protected function ok(mixed $data, int $statusCode = 200): ResponseInterface
+    protected function ok(mixed $data, mixed $meta = null, int $statusCode = 200): ResponseInterface
     {
-        return $this->json(ActionPayload::success($data, null, $statusCode));
+        return $this->json(ActionPayload::success($data, $meta, $statusCode));
     }
 
     /**

--- a/src/Concerns/RespondsWithJson.php
+++ b/src/Concerns/RespondsWithJson.php
@@ -52,7 +52,7 @@ trait RespondsWithJson
      */
     protected function ok(mixed $data, int $statusCode = 200): ResponseInterface
     {
-        return $this->json(ActionPayload::success($data, $statusCode));
+        return $this->json(ActionPayload::success($data, null, $statusCode));
     }
 
     /**

--- a/src/Payloads/ActionPayload.php
+++ b/src/Payloads/ActionPayload.php
@@ -20,11 +20,13 @@ final readonly class ActionPayload implements ActionPayloadInterface
      * @param mixed                     $data       The response data to include, or null when no data is applicable.
      * @param int                       $statusCode The HTTP status code for the response.
      * @param ActionErrorInterface|null $error      An optional structured error to attach for failure responses.
+     * @param mixed                     $meta       Optional metadata to include alongside the data.
      */
     public function __construct(
         private mixed $data = null,
         private int $statusCode = 200,
-        private ?ActionErrorInterface $error = null
+        private ?ActionErrorInterface $error = null,
+        private mixed $meta = null
     ) {
     }
 
@@ -32,13 +34,14 @@ final readonly class ActionPayload implements ActionPayloadInterface
      * Builds a successful payload with the given data.
      *
      * @param mixed $data       The response data to include in the payload.
+     * @param mixed $meta       Optional metadata to include alongside the data.
      * @param int   $statusCode The HTTP status code, defaults to 200.
      *
      * @return self A new success payload instance.
      */
-    public static function success(mixed $data, int $statusCode = 200): self
+    public static function success(mixed $data, mixed $meta = null, int $statusCode = 200): self
     {
-        return new self($data, $statusCode);
+        return new self($data, $statusCode, null, $meta);
     }
 
     /**
@@ -69,7 +72,7 @@ final readonly class ActionPayload implements ActionPayloadInterface
     /**
      * Reduces the payload to an array suitable for JSON serialization.
      *
-     * @return array{data?:mixed,error?:ActionErrorInterface} The serialized payload fields.
+     * @return array{data?:mixed,error?:ActionErrorInterface,meta?:mixed} The serialized payload fields.
      */
     public function jsonSerialize(): array
     {
@@ -81,6 +84,10 @@ final readonly class ActionPayload implements ActionPayloadInterface
 
         if ($this->error !== null) {
             $payload['error'] = $this->error;
+        }
+
+        if ($this->meta !== null) {
+            $payload['meta'] = $this->meta;
         }
 
         return $payload;

--- a/tests/Concerns/RespondsWithJsonTest.php
+++ b/tests/Concerns/RespondsWithJsonTest.php
@@ -96,13 +96,59 @@ final class RespondsWithJsonTest extends TestCase
         $action = new class () extends AbstractAction {
             protected function handle(): ResponseInterface
             {
-                return $this->ok(['id' => 1], 201);
+                return $this->ok(['id' => 1], null, 201);
             }
         };
 
         $response = $this->dispatch($action);
 
         self::assertSame(201, $response->getStatusCode());
+    }
+
+    /**
+     * Asserts that ok method includes meta when provided.
+     */
+    public function testOkIncludesMeta(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->ok(
+                    ['items' => ['a', 'b']],
+                    ['total' => 10, 'page' => 1]
+                );
+            }
+        };
+
+        $response = $this->dispatch($action);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(
+            [
+                'data' => ['items' => ['a', 'b']],
+                'meta' => ['total' => 10, 'page' => 1],
+            ],
+            $this->decodeBody($response)
+        );
+    }
+
+    /**
+     * Asserts that ok method excludes meta when null.
+     */
+    public function testOkExcludesMetaWhenNull(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->ok(['message' => 'success'], null);
+            }
+        };
+
+        $response = $this->dispatch($action);
+
+        $body = $this->decodeBody($response);
+        self::assertArrayHasKey('data', $body);
+        self::assertArrayNotHasKey('meta', $body);
     }
 
     /**

--- a/tests/Payloads/ActionPayloadTest.php
+++ b/tests/Payloads/ActionPayloadTest.php
@@ -22,7 +22,7 @@ final class ActionPayloadTest extends TestCase
      */
     public function testSuccessPayload(): void
     {
-        $payload = ActionPayload::success(['foo' => 'bar'], 201);
+        $payload = ActionPayload::success(['foo' => 'bar'], null, 201);
 
         self::assertSame(201, $payload->getStatusCode());
         self::assertSame(['data' => ['foo' => 'bar']], $payload->jsonSerialize());
@@ -81,6 +81,94 @@ final class ActionPayloadTest extends TestCase
         self::assertJson($json);
         self::assertSame(
             ['data' => ['ok' => true]],
+            json_decode($json, true)
+        );
+    }
+
+    /**
+     * Confirms success payloads with meta include both data and meta fields.
+     *
+     * @return void
+     */
+    public function testSuccessPayloadWithMeta(): void
+    {
+        $data = [
+            ['id' => 1, 'name' => 'Alice'],
+            ['id' => 2, 'name' => 'Bob'],
+        ];
+        $meta = [
+            'total' => 5,
+            'page' => 1,
+            'perPage' => 2,
+            'totalPages' => 3,
+        ];
+
+        $payload = ActionPayload::success($data, $meta, 200);
+
+        self::assertSame(200, $payload->getStatusCode());
+        self::assertSame(
+            [
+                'data' => $data,
+                'meta' => $meta,
+            ],
+            $payload->jsonSerialize()
+        );
+    }
+
+    /**
+     * Ensures meta is excluded when not provided (backwards compatibility).
+     *
+     * @return void
+     */
+    public function testSuccessPayloadWithoutMetaExcludesMetaField(): void
+    {
+        $payload = ActionPayload::success(['foo' => 'bar']);
+
+        $serialized = $payload->jsonSerialize();
+
+        self::assertArrayHasKey('data', $serialized);
+        self::assertArrayNotHasKey('meta', $serialized);
+    }
+
+    /**
+     * Verifies meta preserves falsy values during serialization.
+     *
+     * @return void
+     */
+    public function testMetaPreservesFalsyValues(): void
+    {
+        $meta = [
+            'hasMore' => false,
+            'offset' => 0,
+            'query' => '',
+        ];
+
+        $payload = ActionPayload::success(['items' => []], $meta, 200);
+
+        $serialized = $payload->jsonSerialize();
+
+        self::assertSame($meta, $serialized['meta']);
+    }
+
+    /**
+     * Checks that toJson produces valid JSON with meta field.
+     *
+     * @return void
+     */
+    public function testToJsonWithMetaProducesValidJson(): void
+    {
+        $data = ['users' => []];
+        $meta = ['total' => 0];
+        $payload = ActionPayload::success($data, $meta, 200);
+
+        $json = $payload->toJson();
+
+        self::assertJson($json);
+        self::assertSame(
+            [
+                'data' => $data,
+                'meta' => $meta,
+            ],
             json_decode($json, true)
         );
     }


### PR DESCRIPTION
This pull request introduces support for including an optional `meta` field in JSON responses, allowing additional metadata (such as pagination info) to be returned alongside the main data payload. The changes update the `ok` response helper, the `ActionPayload` class, and related documentation and tests to support and demonstrate this new feature.

**Enhancements to JSON Response Structure:**

* The `ok` method in `AbstractAction` and `RespondsWithJson` now accepts an optional `$meta` parameter, which is included in the response if provided.
* The `ActionPayload` class and its `success` factory method are updated to accept and serialize the `meta` field when present, ensuring backwards compatibility when `meta` is not provided. [[1]](diffhunk://#diff-f736485689a65143f9f15b54d6fb2174e1735d8d7c0d17d0202c4c3604b7e3e1R23-R44) [[2]](diffhunk://#diff-f736485689a65143f9f15b54d6fb2174e1735d8d7c0d17d0202c4c3604b7e3e1L72-R75) [[3]](diffhunk://#diff-f736485689a65143f9f15b54d6fb2174e1735d8d7c0d17d0202c4c3604b7e3e1R89-R92)

**Documentation Updates:**

* The `README.md` is updated to document the new `meta` parameter for the `ok` method, provide usage examples, and show the updated JSON response format with a `meta` field for pagination. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L154-R155) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L242-R242) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R303-R313) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L326-R334)

**Testing Improvements:**

* New and updated tests ensure the correct inclusion and exclusion of the `meta` field, proper serialization (including falsy values), and backwards compatibility. [[1]](diffhunk://#diff-ccbe1fc51f0c05cd8abe4e25bbf939e28373bb825b3ebdc998ae699903632f8fL99-R99) [[2]](diffhunk://#diff-ccbe1fc51f0c05cd8abe4e25bbf939e28373bb825b3ebdc998ae699903632f8fR108-R153) [[3]](diffhunk://#diff-bbf4bfe277f418a14f6002ad535b18feb05cf779cdcc3d99708819748edf46d7L25-R25) [[4]](diffhunk://#diff-bbf4bfe277f418a14f6002ad535b18feb05cf779cdcc3d99708819748edf46d7R87-R174)

These changes make it easier to include structured metadata (such as pagination details) in API responses in a consistent and backward-compatible way.