### PR TITLE
feat: add request attributes handling

### DIFF
--- a/src/AbstractAction.php
+++ b/src/AbstractAction.php
@@ -222,4 +222,33 @@ abstract class AbstractAction
     {
         return $this->json($payload);
     }
+
+    /**
+     * Returns a request attribute.
+     *
+     * @param string $name    The attribute name.
+     * @param mixed  $default The value returned when the attribute is absent.
+     *
+     * @return mixed The attribute value or the supplied default.
+     */
+    protected function getAttribute(string $name, mixed $default = null): mixed
+    {
+        return $this->request->getAttribute($name, $default);
+    }
+
+    /**
+     * Resolves a required request attribute.
+     *
+     * @throws RuntimeException When the attribute is absent.
+     */
+    protected function resolveAttribute(string $name): mixed
+    {
+        $attributes = $this->request->getAttributes();
+
+        if (!array_key_exists($name, $attributes)) {
+            throw new RuntimeException("Missing request attribute: {$name}");
+        }
+
+        return $attributes[$name];
+    }
 }

--- a/tests/AbstractActionTest.php
+++ b/tests/AbstractActionTest.php
@@ -757,4 +757,144 @@ final class AbstractActionTest extends TestCase
 
         $action($this->makeRequest('GET', '/items'), $this->makeResponse(), []);
     }
+
+    /**
+     * Asserts that getAttribute returns an existing request attribute.
+     */
+    public function testGetAttributeReturnsAttribute(): void
+    {
+        $request = $this->makeRequest('GET', '/protected')
+            ->withAttribute('user', 'authenticated-user');
+
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->json(ActionPayload::success([
+                    'user' => $this->getAttribute('user'),
+                ]));
+            }
+        };
+
+        $result = $action($request, $this->makeResponse(), []);
+        $decoded = json_decode(
+            (string)$result->getBody(),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+
+        self::assertSame('authenticated-user', $decoded['data']['user']);
+    }
+
+    /**
+     * Asserts that getAttribute returns the supplied default when the attribute is absent.
+     */
+    public function testGetAttributeReturnsDefaultWhenMissing(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->json(ActionPayload::success([
+                    'locale' => $this->getAttribute('locale', 'en'),
+                ]));
+            }
+        };
+
+        $result = $action(
+            $this->makeRequest('GET', '/'),
+            $this->makeResponse(),
+            []
+        );
+
+        $decoded = json_decode(
+            (string)$result->getBody(),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+
+        self::assertSame('en', $decoded['data']['locale']);
+    }
+
+    /**
+     * Asserts that resolveAttribute returns an existing required request attribute.
+     */
+    public function testResolveAttributeReturnsAttribute(): void
+    {
+        $request = $this->makeRequest('GET', '/protected')
+            ->withAttribute('user', 'authenticated-user');
+
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->json(ActionPayload::success([
+                    'user' => $this->resolveAttribute('user'),
+                ]));
+            }
+        };
+
+        $result = $action($request, $this->makeResponse(), []);
+        $decoded = json_decode(
+            (string)$result->getBody(),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+
+        self::assertSame('authenticated-user', $decoded['data']['user']);
+    }
+
+    /**
+     * Asserts that resolveAttribute distinguishes an existing null value from a missing attribute.
+     */
+    public function testResolveAttributeReturnsExistingNullAttribute(): void
+    {
+        $request = $this->makeRequest('GET', '/')
+            ->withAttribute('tenant', null);
+
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->json(ActionPayload::success([
+                    'tenant' => $this->resolveAttribute('tenant'),
+                ]));
+            }
+        };
+
+        $result = $action($request, $this->makeResponse(), []);
+
+        $decoded = json_decode(
+            (string)$result->getBody(),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+
+        self::assertArrayHasKey('tenant', $decoded['data']);
+        self::assertNull($decoded['data']['tenant']);
+    }
+
+    /**
+     * Asserts that resolveAttribute throws when the required request attribute is absent.
+     */
+    public function testResolveAttributeThrowsWhenMissing(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                $this->resolveAttribute('user');
+
+                return $this->json(ActionPayload::success([]));
+            }
+        };
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Missing request attribute: user');
+
+        $action(
+            $this->makeRequest('GET', '/protected'),
+            $this->makeResponse(),
+            []
+        );
+    }
 }


### PR DESCRIPTION
## Description

This pull request introduces two new helper methods to the `AbstractAction` class for retrieving request attributes, along with comprehensive tests to ensure their correct behavior. These changes improve how request attributes are accessed, making the code more robust and expressive.

## Proposed Changes

**Enhancements to request attribute handling:**

* [`AbstractAction.php`](diffhunk://#diff-116fe25fa78509c6571a37859b540883047cba7eb993aa7e7b36283849a8ace7R225-R253): Added the `getAttribute` method to retrieve a request attribute with an optional default value if the attribute is missing.
* [`AbstractAction.php`](diffhunk://#diff-116fe25fa78509c6571a37859b540883047cba7eb993aa7e7b36283849a8ace7R225-R253): Added the `resolveAttribute` method to retrieve a required request attribute, throwing a `RuntimeException` if the attribute is not present.

**Testing improvements:**

* [`AbstractActionTest.php`](diffhunk://#diff-9aee27bf40a1de5c43d3e4a2f820b75e20d4a3fe339f9dcdf5bbdf96df1b6dafR760-R899): Added tests for `getAttribute` to verify it returns existing attributes and the supplied default when missing.
* [`AbstractActionTest.php`](diffhunk://#diff-9aee27bf40a1de5c43d3e4a2f820b75e20d4a3fe339f9dcdf5bbdf96df1b6dafR760-R899): Added tests for `resolveAttribute` to verify it returns existing attributes (including `null` values) and throws an exception when the attribute is missing.

## Type of Change

- [x] `feat` — new feature (minor version bump)
- [ ] `fix` — bug fix (patch version bump)
- [ ] `deps` — dependency update (patch version bump when releasable)
- [ ] `chore` / `docs` / `refactor` / `test` / `ci` / `build` — no version bump
- [ ] `feat!` or `BREAKING CHANGE:` — breaking change (major version bump)

## Related Issue

<!-- Link to the issue this addresses, if applicable: Closes #123 -->

## Checklist

- [x] PR title follows Conventional Commits format: `<type>[optional scope]: <description>`
- [x] Description is a single paragraph suitable for the squash-merge commit body
- [x] PHP code has been formatted with `composer cs` (when applicable)
- [x] Tests have been added or updated where appropriate
- [x] All tests pass with `composer test`
- [ ] Dependency changes are reflected in `composer.json` and `composer.lock` where appropriate
- [ ] Breaking changes in updated dependencies have been assessed (dependency changes only)
- [ ] Fix has been verified locally (bug fixes only)
