### PR TITLE
feat: add error handling responses

### DIFF
--- a/src/AbstractAction.php
+++ b/src/AbstractAction.php
@@ -7,6 +7,7 @@ namespace AndrewDyer\Actions;
 use AndrewDyer\Actions\Concerns\RespondsWithJson;
 use AndrewDyer\Actions\Contracts\ActionPayloadInterface;
 use AndrewDyer\Actions\Contracts\BadRequestExceptionInterface;
+use AndrewDyer\Actions\Contracts\ConflictExceptionInterface;
 use AndrewDyer\Actions\Contracts\ForbiddenExceptionInterface;
 use AndrewDyer\Actions\Contracts\NotFoundExceptionInterface;
 use AndrewDyer\Actions\Contracts\NotImplementedExceptionInterface;
@@ -59,6 +60,8 @@ abstract class AbstractAction
             return $this->handle();
         } catch (BadRequestExceptionInterface $e) {
             return $this->badRequest($this->getExceptionMessage($e));
+        } catch (ConflictExceptionInterface $e) {
+            return $this->conflict($this->getExceptionMessage($e));
         } catch (ForbiddenExceptionInterface $e) {
             return $this->forbidden($this->getExceptionMessage($e));
         } catch (NotFoundExceptionInterface $e) {

--- a/src/Concerns/RespondsWithJson.php
+++ b/src/Concerns/RespondsWithJson.php
@@ -35,6 +35,20 @@ trait RespondsWithJson
     }
 
     /**
+     * Responds with a 409 Conflict JSON error payload.
+     *
+     * @param string|null $description An optional human-readable description of the error.
+     *
+     * @throws JsonException When the payload cannot be JSON-encoded.
+     *
+     * @return ResponseInterface The JSON response.
+     */
+    protected function conflict(?string $description = null): ResponseInterface
+    {
+        return $this->json(ActionPayload::error(ActionError::conflict($description), 409));
+    }
+
+    /**
      * Responds with a 403 Forbidden JSON error payload.
      *
      * @param string|null $description An optional human-readable description of the error.

--- a/src/Concerns/RespondsWithJson.php
+++ b/src/Concerns/RespondsWithJson.php
@@ -155,6 +155,20 @@ trait RespondsWithJson
     }
 
     /**
+     * Responds with a 429 Too Many Requests JSON error payload.
+     *
+     * @param string|null $description An optional human-readable description of the error.
+     *
+     * @throws JsonException When the payload cannot be JSON-encoded.
+     *
+     * @return ResponseInterface The JSON response.
+     */
+    protected function tooManyRequests(?string $description = null): ResponseInterface
+    {
+        return $this->json(ActionPayload::error(ActionError::tooManyRequests($description), 429));
+    }
+
+    /**
      * Responds with a 401 Unauthorized JSON error payload.
      *
      * @param string|null $description An optional human-readable description of the error.

--- a/src/Contracts/ConflictExceptionInterface.php
+++ b/src/Contracts/ConflictExceptionInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AndrewDyer\Actions\Contracts;
+
+use Throwable;
+
+/**
+ * Identifies an exception caused by a conflict with the current resource state.
+ *
+ * @api
+ */
+interface ConflictExceptionInterface extends Throwable
+{
+}

--- a/src/Exceptions/ConflictException.php
+++ b/src/Exceptions/ConflictException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AndrewDyer\Actions\Exceptions;
+
+use AndrewDyer\Actions\Contracts\ConflictExceptionInterface;
+use Exception;
+
+/**
+ * Concrete exception representing a resource conflict.
+ *
+ * Domain-specific exceptions may extend this class to automatically return a
+ * 409 JSON response from an action.
+ *
+ * @api
+ */
+class ConflictException extends Exception implements ConflictExceptionInterface
+{
+}

--- a/src/Payloads/ActionError.php
+++ b/src/Payloads/ActionError.php
@@ -96,6 +96,18 @@ final readonly class ActionError extends AbstractActionError
     }
 
     /**
+     * Creates a too many requests error representation.
+     *
+     * @param string|null $description An optional human-readable description of the error.
+     *
+     * @return self A new instance representing a rate limit error.
+     */
+    public static function tooManyRequests(?string $description = null): self
+    {
+        return new self(self::TOO_MANY_REQUESTS, $description);
+    }
+
+    /**
      * Creates an unauthenticated error representation.
      *
      * @param string|null $description An optional human-readable description of the error.
@@ -126,6 +138,9 @@ final readonly class ActionError extends AbstractActionError
 
     /** Indicates an unexpected internal server failure. */
     public const string SERVER_ERROR = 'SERVER_ERROR';
+
+    /** Indicates the caller has exceeded the permitted request rate. */
+    public const string TOO_MANY_REQUESTS = 'TOO_MANY_REQUESTS';
 
     /** Indicates the request lacks valid authentication credentials. */
     public const string UNAUTHENTICATED = 'UNAUTHENTICATED';

--- a/src/Payloads/ActionError.php
+++ b/src/Payloads/ActionError.php
@@ -24,6 +24,18 @@ final readonly class ActionError extends AbstractActionError
     }
 
     /**
+     * Creates a resource conflict error representation.
+     *
+     * @param string|null $description An optional human-readable description of the error.
+     *
+     * @return self A new instance representing a resource conflict.
+     */
+    public static function conflict(?string $description = null): self
+    {
+        return new self(self::RESOURCE_CONFLICT, $description);
+    }
+
+    /**
      * Creates an insufficient privileges error representation.
      *
      * @param string|null $description An optional human-readable description of the error.
@@ -105,6 +117,9 @@ final readonly class ActionError extends AbstractActionError
 
     /** Indicates the requested functionality has not yet been implemented. */
     public const string NOT_IMPLEMENTED = 'NOT_IMPLEMENTED';
+
+    /** Indicates a conflict with the current state of a resource. */
+    public const string RESOURCE_CONFLICT = 'RESOURCE_CONFLICT';
 
     /** Indicates the requested resource could not be found. */
     public const string RESOURCE_NOT_FOUND = 'RESOURCE_NOT_FOUND';

--- a/tests/AbstractActionTest.php
+++ b/tests/AbstractActionTest.php
@@ -6,6 +6,7 @@ namespace AndrewDyer\Actions\Tests;
 
 use AndrewDyer\Actions\AbstractAction;
 use AndrewDyer\Actions\Exceptions\BadRequestException;
+use AndrewDyer\Actions\Exceptions\ConflictException;
 use AndrewDyer\Actions\Exceptions\ForbiddenException;
 use AndrewDyer\Actions\Exceptions\NotFoundException;
 use AndrewDyer\Actions\Exceptions\NotImplementedException;
@@ -58,6 +59,27 @@ final class AbstractActionTest extends TestCase
         self::assertArrayNotHasKey('data', $decoded);
         self::assertSame(ActionError::BAD_REQUEST, $decoded['error']['type'] ?? null);
         self::assertSame('Invalid email format', $decoded['error']['description'] ?? null);
+    }
+
+    /**
+     * Asserts that ConflictException is caught and returns a 409 JSON response.
+     */
+    public function testCatchesConflictException(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                throw new ConflictException('Resource already exists');
+            }
+        };
+
+        $result = $action($this->makeRequest('POST', '/things'), $this->makeResponse(), []);
+
+        self::assertSame(409, $result->getStatusCode());
+
+        $decoded = json_decode((string)$result->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame(ActionError::RESOURCE_CONFLICT, $decoded['error']['type']);
+        self::assertSame('Resource already exists', $decoded['error']['description']);
     }
 
     /**

--- a/tests/Concerns/RespondsWithJsonTest.php
+++ b/tests/Concerns/RespondsWithJsonTest.php
@@ -112,6 +112,47 @@ final class RespondsWithJsonTest extends TestCase
     }
 
     /**
+     * Asserts that conflict method accepts a null description.
+     */
+    public function testConflictAcceptsNullDescription(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->conflict();
+            }
+        };
+
+        $response = $this->dispatch($action);
+
+        self::assertSame(409, $response->getStatusCode());
+
+        $body = $this->decodeBody($response);
+        self::assertArrayNotHasKey('description', $body['error']);
+    }
+
+    /**
+     * Asserts that conflict method returns 409 with a RESOURCE_CONFLICT error type.
+     */
+    public function testConflictReturns409(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->conflict('Resource already exists.');
+            }
+        };
+
+        $response = $this->dispatch($action);
+
+        self::assertSame(409, $response->getStatusCode());
+
+        $body = $this->decodeBody($response);
+        self::assertSame(ActionError::RESOURCE_CONFLICT, $body['error']['type']);
+        self::assertSame('Resource already exists.', $body['error']['description']);
+    }
+
+    /**
      * Asserts that forbidden method accepts a null description.
      */
     public function testForbiddenAcceptsNullDescription(): void

--- a/tests/Concerns/RespondsWithJsonTest.php
+++ b/tests/Concerns/RespondsWithJsonTest.php
@@ -434,6 +434,47 @@ final class RespondsWithJsonTest extends TestCase
     }
 
     /**
+     * Asserts that tooManyRequests method accepts a null description.
+     */
+    public function testTooManyRequestsAcceptsNullDescription(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->tooManyRequests();
+            }
+        };
+
+        $response = $this->dispatch($action);
+
+        self::assertSame(429, $response->getStatusCode());
+
+        $body = $this->decodeBody($response);
+        self::assertArrayNotHasKey('description', $body['error']);
+    }
+
+    /**
+     * Asserts that tooManyRequests method returns 429 with a TOO_MANY_REQUESTS error type.
+     */
+    public function testTooManyRequestsReturns429(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->tooManyRequests('Rate limit exceeded.');
+            }
+        };
+
+        $response = $this->dispatch($action);
+
+        self::assertSame(429, $response->getStatusCode());
+
+        $body = $this->decodeBody($response);
+        self::assertSame(ActionError::TOO_MANY_REQUESTS, $body['error']['type']);
+        self::assertSame('Rate limit exceeded.', $body['error']['description']);
+    }
+
+    /**
      * Asserts that unauthorized method accepts a null description.
      */
     public function testUnauthorizedAcceptsNullDescription(): void

--- a/tests/Payloads/ActionErrorTest.php
+++ b/tests/Payloads/ActionErrorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AndrewDyer\Actions\Tests\Payloads;
 
 use AndrewDyer\Actions\Payloads\ActionError;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -22,6 +23,7 @@ final class ActionErrorTest extends TestCase
     public static function factoryProvider(): iterable
     {
         yield 'bad request with description' => ['badRequest', ActionError::BAD_REQUEST, 'Invalid input'];
+        yield 'conflict' => ['conflict', ActionError::RESOURCE_CONFLICT, 'Resource already exists'];
         yield 'not found default description' => ['notFound', ActionError::RESOURCE_NOT_FOUND, null];
         yield 'not allowed' => ['notAllowed', ActionError::NOT_ALLOWED, 'Method not allowed'];
         yield 'unauthenticated' => ['unauthenticated', ActionError::UNAUTHENTICATED, 'Missing token'];
@@ -33,14 +35,13 @@ final class ActionErrorTest extends TestCase
     /**
      * Ensures each factory emits the expected error metadata.
      *
-     * @dataProvider factoryProvider
-     *
      * @param string      $factoryMethod
      * @param string      $expectedType
      * @param string|null $description
      *
      * @return void
      */
+    #[DataProvider('factoryProvider')]
     public function testFactoryOutputs(string $factoryMethod, string $expectedType, ?string $description): void
     {
         $error = ActionError::$factoryMethod($description);

--- a/tests/Payloads/ActionErrorTest.php
+++ b/tests/Payloads/ActionErrorTest.php
@@ -30,6 +30,7 @@ final class ActionErrorTest extends TestCase
         yield 'insufficient privileges' => ['insufficientPrivileges', ActionError::INSUFFICIENT_PRIVILEGES, 'Need admin role'];
         yield 'not implemented' => ['notImplemented', ActionError::NOT_IMPLEMENTED, 'Coming soon'];
         yield 'server error' => ['serverError', ActionError::SERVER_ERROR, 'Unexpected failure'];
+        yield 'too many requests' => ['tooManyRequests', ActionError::TOO_MANY_REQUESTS, 'Rate limit exceeded'];
     }
 
     /**


### PR DESCRIPTION
This pull request adds support for handling HTTP 409 (Conflict) and 429 (Too Many Requests) error responses throughout the action framework. It introduces new exception types, error payloads, and response helpers for these cases, and ensures they are properly handled and tested. The changes improve the expressiveness and robustness of error handling in actions.

**Error Handling Enhancements**

* Added `ConflictExceptionInterface` and a concrete `ConflictException` class to represent resource conflict errors (409), and updated `AbstractAction` to catch and handle these exceptions with a proper JSON response. [[1]](diffhunk://#diff-d0d93f075c29ebff02c96e041e49c11bfba614b235e6737d5e28d13eb7060706R1-R16) [[2]](diffhunk://#diff-6fe18caeccdf5298d468beecbef91f68979cfd9a87548633bc2a41af0db3ea8dR1-R20) [[3]](diffhunk://#diff-116fe25fa78509c6571a37859b540883047cba7eb993aa7e7b36283849a8ace7R10) [[4]](diffhunk://#diff-116fe25fa78509c6571a37859b540883047cba7eb993aa7e7b36283849a8ace7R63-R64)
* Added `tooManyRequests` response helper (429) to `RespondsWithJson`, allowing actions to return rate limit errors, and corresponding error payloads in `ActionError`. [[1]](diffhunk://#diff-9acdee8e94a079f00e8b11743b09a97fe7ec7dd043a902e8c45aba56ceacfe27R157-R170) [[2]](diffhunk://#diff-6b32921671ad4fd6585be766d657ed18f8e589b3bbd7584d171742221f52fec4R98-R109) [[3]](diffhunk://#diff-6b32921671ad4fd6585be766d657ed18f8e589b3bbd7584d171742221f52fec4R133-R144)

**Error Payloads and Constants**

* Introduced new error types and factory methods in `ActionError` for `RESOURCE_CONFLICT` and `TOO_MANY_REQUESTS`, with appropriate descriptions and status codes. [[1]](diffhunk://#diff-6b32921671ad4fd6585be766d657ed18f8e589b3bbd7584d171742221f52fec4R26-R37) [[2]](diffhunk://#diff-6b32921671ad4fd6585be766d657ed18f8e589b3bbd7584d171742221f52fec4R98-R109) [[3]](diffhunk://#diff-6b32921671ad4fd6585be766d657ed18f8e589b3bbd7584d171742221f52fec4R133-R144)

**Testing Improvements**

* Added and extended tests to cover the new 409 and 429 error cases, including tests for the new exception, response helpers, and error payloads. [[1]](diffhunk://#diff-9aee27bf40a1de5c43d3e4a2f820b75e20d4a3fe339f9dcdf5bbdf96df1b6dafR64-R84) [[2]](diffhunk://#diff-ccbe1fc51f0c05cd8abe4e25bbf939e28373bb825b3ebdc998ae699903632f8fR114-R154) [[3]](diffhunk://#diff-ccbe1fc51f0c05cd8abe4e25bbf939e28373bb825b3ebdc998ae699903632f8fR436-R476) [[4]](diffhunk://#diff-5fb40d4ea8d25f13128cd918c91f451940dcb22a0a5ed5298eae755e1fc07b45R26-R45)

These changes collectively make error handling more comprehensive and standardized for common API error scenarios.