### PR TITLE
feat: add document method

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,22 +144,35 @@ Accept: application/json
 
 ## Response helpers
 
-Helper methods provided by `AbstractAction` generate structured JSON responses. Each builds the appropriate `ActionPayload` and writes it to the response.
+Helper methods provided by `AbstractAction` generate JSON responses. Most build
+an `ActionPayload` envelope; `document()` preserves a standards-defined
+top-level JSON structure.
 
-| Method                                                       | When to use                                      | Status          | Error type                |
-| ------------------------------------------------------------ | ------------------------------------------------ | --------------- | ------------------------- |
-| `ok(mixed $data, mixed $meta = null, int $statusCode = 200)` | Successful operation with data payload           | 200 (or custom) | —                         |
-| `badRequest(?string $description = null)`                    | Request is malformed or violates business rules  | 400             | `BAD_REQUEST`             |
-| `unauthorized(?string $description = null)`                  | Request lacks valid authentication credentials   | 401             | `UNAUTHENTICATED`         |
-| `forbidden(?string $description = null)`                     | Authenticated caller lacks required permissions  | 403             | `INSUFFICIENT_PRIVILEGES` |
-| `notFound(?string $description = null)`                      | Requested resource does not exist                | 404             | `RESOURCE_NOT_FOUND`      |
-| `notAllowed(?string $description = null)`                    | HTTP method not allowed for the resource         | 405             | `NOT_ALLOWED`             |
-| `serverError(?string $description = null)`                   | Unexpected server error occurred                 | 500             | `SERVER_ERROR`            |
-| `notImplemented(?string $description = null)`                | Requested functionality has not been implemented | 501             | `NOT_IMPLEMENTED`         |
+| Method                                                                                      | When to use                                           | Status          | Error type                |
+| ------------------------------------------------------------------------------------------- | ----------------------------------------------------- | --------------- | ------------------------- |
+| `ok(mixed $data, mixed $meta = null, int $statusCode = 200)`                                | Successful operation with data payload                | 200 (or custom) | —                         |
+| `document(mixed $data, int $statusCode = 200, array $headers = [])`                          | Unwrapped standards-defined JSON document             | 200 (or custom) | —                         |
+| `badRequest(?string $description = null)`                                                   | Request is malformed or violates business rules       | 400             | `BAD_REQUEST`             |
+| `unauthorized(?string $description = null)`                                                 | Request lacks valid authentication credentials        | 401             | `UNAUTHENTICATED`         |
+| `forbidden(?string $description = null)`                                                    | Authenticated caller lacks required permissions       | 403             | `INSUFFICIENT_PRIVILEGES` |
+| `notFound(?string $description = null)`                                                     | Requested resource does not exist                     | 404             | `RESOURCE_NOT_FOUND`      |
+| `notAllowed(?string $description = null)`                                                   | HTTP method not allowed for the resource               | 405             | `NOT_ALLOWED`             |
+| `serverError(?string $description = null)`                                                  | Unexpected server error occurred                      | 500             | `SERVER_ERROR`            |
+| `notImplemented(?string $description = null)`                                               | Requested functionality has not been implemented      | 501             | `NOT_IMPLEMENTED`         |
 
 > **Note:** When the `description` parameter is `null`, the `description` field is omitted entirely from the error response. API consumers should treat `description` as an optional field.
 
 For full control over the payload, call `json(ActionPayloadInterface $payload)` directly.
+
+Use `document()` when an external specification requires fields at the root of
+the response rather than inside the usual `data` envelope:
+
+```php
+return $this->document(
+    ['active' => false],
+    headers: ['Cache-Control' => 'no-store'],
+);
+```
 
 ## Request helpers
 

--- a/src/Concerns/RespondsWithJson.php
+++ b/src/Concerns/RespondsWithJson.php
@@ -49,6 +49,35 @@ trait RespondsWithJson
     }
 
     /**
+     * Responds with a direct JSON document without an action-payload envelope.
+     *
+     * @param mixed                          $data       The value to JSON-encode.
+     * @param int                            $statusCode The HTTP status code.
+     * @param array<string, string|string[]> $headers    Additional response headers.
+     *
+     * @throws JsonException When the document cannot be JSON-encoded.
+     *
+     * @return ResponseInterface The JSON document response.
+     */
+    protected function document(
+        mixed $data,
+        int $statusCode = 200,
+        array $headers = [],
+    ): ResponseInterface {
+        $json = json_encode($data, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $this->response->getBody()->write($json);
+        $response = $this->response
+            ->withHeader('Content-Type', 'application/json; charset=utf-8')
+            ->withStatus($statusCode);
+
+        foreach ($headers as $name => $value) {
+            $response = $response->withHeader($name, $value);
+        }
+
+        return $response;
+    }
+
+    /**
      * Responds with a 403 Forbidden JSON error payload.
      *
      * @param string|null $description An optional human-readable description of the error.

--- a/tests/Concerns/RespondsWithJsonTest.php
+++ b/tests/Concerns/RespondsWithJsonTest.php
@@ -153,6 +153,49 @@ final class RespondsWithJsonTest extends TestCase
     }
 
     /**
+     * Asserts that document applies a custom status and response headers.
+     */
+    public function testDocumentAppliesCustomStatusAndHeaders(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->document(
+                    ['active' => false],
+                    202,
+                    ['Cache-Control' => 'no-store', 'X-Test' => ['one', 'two']],
+                );
+            }
+        };
+
+        $response = $this->dispatch($action);
+
+        self::assertSame(202, $response->getStatusCode());
+        self::assertSame('no-store', $response->getHeaderLine('Cache-Control'));
+        self::assertSame(['one', 'two'], $response->getHeader('X-Test'));
+        self::assertSame(['active' => false], $this->decodeBody($response));
+    }
+
+    /**
+     * Asserts that document returns data without an action-payload envelope.
+     */
+    public function testDocumentReturnsAnUnwrappedJsonDocument(): void
+    {
+        $action = new class () extends AbstractAction {
+            protected function handle(): ResponseInterface
+            {
+                return $this->document(['keys' => [['kid' => 'identity-key']]]);
+            }
+        };
+
+        $response = $this->dispatch($action);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('application/json; charset=utf-8', $response->getHeaderLine('Content-Type'));
+        self::assertSame(['keys' => [['kid' => 'identity-key']]], $this->decodeBody($response));
+    }
+
+    /**
      * Asserts that forbidden method accepts a null description.
      */
     public function testForbiddenAcceptsNullDescription(): void


### PR DESCRIPTION
This pull request introduces a new `document()` response helper for returning unwrapped JSON documents, updates the documentation to explain its use, and adds tests to ensure its correct behavior. The main goal is to support standards-defined JSON structures at the top level of the response, rather than always wrapping data in an `ActionPayload` envelope.

**Enhancements to JSON response handling:**

* Added the `document()` method to `RespondsWithJson` for sending direct JSON documents without the `ActionPayload` envelope, supporting custom status codes and headers.
* Updated the `README.md` to document the new `document()` helper, clarify when to use it, and provide usage examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L147-R154) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R167-R176)

**Testing improvements:**

* Added tests to verify that `document()` applies custom status and headers and returns unwrapped JSON data as expected.